### PR TITLE
Fix bug in 'masking ancillary' step

### DIFF
--- a/src/dswx_sar/defaults/algorithm_parameter_s1.yaml
+++ b/src/dswx_sar/defaults/algorithm_parameter_s1.yaml
@@ -18,7 +18,7 @@ runconfig:
             # number of pixel to apply erosion for drought case
             drought_erosion_pixel: 10
             # number of pixel to apply dilation for flood case
-            flood_dilation_pixel: 16 
+            flood_dilation_pixel: 16
 
         hand:
             mask_value: 200
@@ -27,8 +27,8 @@ runconfig:
             mosaic_prefix: 'mosaic'
             mosaic_cog_enable: True
             # Burst Mosaic options
-            #   - average : overlapped areas are averaged. 
-            #   - first : choose one burst without average. 
+            #   - average : overlapped areas are averaged.
+            #   - first : choose one burst without average.
             mosaic_mode: 'first'
 
         # Flag to turn on/off the filtering for RTC image.
@@ -53,11 +53,11 @@ runconfig:
             selection_method: 'combined'
 
             # Thresholds to select tiles showing the boundary between water and nonwater
-            # using bimodality strategy. 
-            # One values are required for twele method 
+            # using bimodality strategy.
+            # One values are required for twele method
             tile_selection_twele: [0.09, 0.8, 0.97]
             # Thresholds to select tiles showing the boundary between water and nonwater
-            # using bimodality strategy. 
+            # using bimodality strategy.
             # One values are required for bimodality method
             tile_selection_bimodality: 0.7
             # Stratey to interpolate the tile-based thresholds.
@@ -82,23 +82,23 @@ runconfig:
         fuzzy_value:
             line_per_block: 200
             hand:
-                # The units of the HAND is meters. 
+                # The units of the HAND is meters.
                 member_min: 0
                 member_max: 15
             # membership bound for slope angle
             slope:
-                # The units of the slope is degree. 
+                # The units of the slope is degree.
                 member_min: 0.5
                 member_max: 15
-            # membership bound for reference water                
+            # membership bound for reference water
             reference_water:
                 # Minimum reference water value for membership
                 member_min: 0.8
                 # Maximum reference water value for membership
                 member_max: 0.95
             # membership bound for area of initial water bodies
-            # area membership is only required for 'twele' workflow. 
-            # area unit is pixel number. 
+            # area membership is only required for 'twele' workflow.
+            # area unit is pixel number.
             area:
                 member_min: 0
                 member_max: 40
@@ -130,7 +130,7 @@ runconfig:
             co_pol_threshold: -14.6
             cross_pol_threshold: -22.8
             # reference water threshold value for dark land candidates
-            water_threshold: 
+            water_threshold:
             number_cpu: 1
 
         refine_with_bimodality:

--- a/src/dswx_sar/defaults/algorithm_parameter_s1.yaml
+++ b/src/dswx_sar/defaults/algorithm_parameter_s1.yaml
@@ -131,6 +131,7 @@ runconfig:
             cross_pol_threshold: -22.8
             # reference water threshold value for dark land candidates
             water_threshold: 
+            number_cpu: 1
 
         refine_with_bimodality:
             minimum_pixel: 4

--- a/src/dswx_sar/masking_with_ancillary.py
+++ b/src/dswx_sar/masking_with_ancillary.py
@@ -128,8 +128,7 @@ def extract_bbox_with_buffer(
 
     sizes = stats_water[1:, -1]
     bboxes = stats_water[1:, :4]
-    print('extract bbox', np.shape(sizes))
-    print('extract bbox2', np.shape(bboxes))
+
     coord_list = []
     for i, (x, y, w, h) in enumerate(bboxes):
         # additional buffer areas should be balanced with the object area.

--- a/src/dswx_sar/masking_with_ancillary.py
+++ b/src/dswx_sar/masking_with_ancillary.py
@@ -312,7 +312,8 @@ def split_extended_water_parallel(
         pol_ind: int,
         outputdir: str,
         meta_info: dict,
-        input_dict: dict) -> np.ndarray:
+        input_dict: dict,
+        number_workers : int) -> np.ndarray:
     """Split extended water areas into smaller subsets based on
     bounding boxes with buffer.
 
@@ -361,7 +362,7 @@ def split_extended_water_parallel(
 
     # check if the objects have heterogeneous characteristics (bimodality)
     # If so, split the objects using multi-otsu thresholds and check bimodality.
-    results = Parallel(n_jobs=-1)(delayed(check_water_land_mixture)(args)
+    results = Parallel(n_jobs=number_workers)(delayed(check_water_land_mixture)(args)
                                   for args in args_list)
 
     # If water need to be refined (change_flat=True), then update the water mask.
@@ -380,6 +381,7 @@ def compute_spatial_coverage_from_ancillary_parallel(
         outputdir: str,
         meta_info: dict,
         spatial_coverage_threshold: float = 0.5,
+        number_workers: int = -1,
     ) -> np.ndarray:
     """Compute spatial coverage of water areas based on ancillary information.
 
@@ -445,7 +447,7 @@ def compute_spatial_coverage_from_ancillary_parallel(
 
     # Output consists of index and 2D image consisting of True/Flase.
     # True represents the land and False represents not-land.
-    results = Parallel(n_jobs=10)(delayed(compute_spatial_coverage)(args)
+    results = Parallel(n_jobs=number_workers)(delayed(compute_spatial_coverage)(args)
                                   for args in args_list)
     for i, test_output_i in results:
         test_output[i] = test_output_i
@@ -514,7 +516,8 @@ def run(cfg):
 
     water_cfg = processing_cfg.reference_water
     ref_water_max = water_cfg.max_value
-    ref_no_data = water_cfg.no_data_value
+    masking_ancillary_cfg = processing_cfg.masking_ancillary
+    number_workers = masking_ancillary_cfg.number_cpu
 
     landcover_cfg = processing_cfg.masking_ancillary
 
@@ -589,7 +592,8 @@ def run(cfg):
         co_pol_ind,
         outputdir,
         water_meta,
-        input_file_dict)
+        input_file_dict,
+        number_workers)
 
     # 4) re-define false water candidate estimated from 'split_extended_water_parallel'
     # by considering the spatial coverage with the ancillary files
@@ -599,15 +603,12 @@ def run(cfg):
                     ref_water=interp_wbd/ref_water_max,
                     mask_landcover=mask_excluded_landcover,
                     outputdir=outputdir,
-                    meta_info=water_meta)
+                    meta_info=water_meta,
+                    number_workers=number_workers)
 
     dark_land = (mask_water_image == 1) | mask_excluded
 
     water_map[dark_land] = 0
-
-    # areas where pixeles are "no_data" in both reference water map and landcover
-    landcover_nodata = mask_obj.get_mask(mask_label=['No_data'])
-    no_data_area = (interp_wbd == ref_no_data) & (landcover_nodata)
 
     water_tif_str = os.path.join(outputdir,
                                  f"refine_landcover_binary_{pol_str}.tif")
@@ -618,8 +619,7 @@ def run(cfg):
         projection=water_meta['projection'],
         description='Water classification (WTR)',
         scratch_dir=outputdir,
-        dark_land=dark_land,
-        no_data=no_data_area)
+        dark_land=dark_land)
 
     if processing_cfg.debug_mode:
 

--- a/src/dswx_sar/refine_with_bimodality.py
+++ b/src/dswx_sar/refine_with_bimodality.py
@@ -1078,7 +1078,7 @@ def run(cfg):
     # Identify the non-water area from Landcover map
     if 'openSea' in landcover_label:
         landcover_not_water = (landcover_map != landcover_label['openSea']) &\
-             (landcover_map != landcover_label['Permanent water bodies']) 
+             (landcover_map != landcover_label['Permanent water bodies'])
     else:
         landcover_not_water = (landcover_map != landcover_label['Permanent water bodies']) &\
                               (landcover_map != landcover_label['No_data'])

--- a/src/dswx_sar/refine_with_bimodality.py
+++ b/src/dswx_sar/refine_with_bimodality.py
@@ -790,6 +790,7 @@ def remove_false_water_bimodality_parallel(water_mask,
                     output_file=water_label_str,
                     geotransform=meta_info['geotransform'],
                     projection=meta_info['projection'],
+                    datatype='int32',
                     scratch_dir=outputdir)
 
     bimodality_set = []
@@ -963,6 +964,7 @@ def fill_gap_water_bimodality_parallel(
                     output_file=water_label_str,
                     geotransform=meta_info['geotransform'],
                     projection=meta_info['projection'],
+                    datatype='int32',
                     scratch_dir=outputdir)
 
     bimodality_set = []
@@ -1040,7 +1042,6 @@ def run(cfg):
     pol_list = processing_cfg.polarizations
     pol_str = '_'.join(pol_list)
     co_pol = processing_cfg.copol
-    cross_pol = processing_cfg.crosspol
 
     bimodality_cfg = processing_cfg.refine_with_bimodality
     minimum_pixel = bimodality_cfg.minimum_pixel
@@ -1077,9 +1078,10 @@ def run(cfg):
     # Identify the non-water area from Landcover map
     if 'openSea' in landcover_label:
         landcover_not_water = (landcover_map != landcover_label['openSea']) &\
-             (landcover_map != landcover_label['Permanent water bodies'])
+             (landcover_map != landcover_label['Permanent water bodies']) 
     else:
-        landcover_not_water = (landcover_map != landcover_label['Permanent water bodies'])
+        landcover_not_water = (landcover_map != landcover_label['Permanent water bodies']) &\
+                              (landcover_map != landcover_label['No_data'])
 
     ref_land_str = os.path.join(outputdir,
                                 f'landcover_not_water_{pol_str}.tif')

--- a/src/dswx_sar/schemas/algorithm_parameter_s1.yaml
+++ b/src/dswx_sar/schemas/algorithm_parameter_s1.yaml
@@ -125,6 +125,7 @@ runconfig:
             cross_pol_threshold: num(min=-30, max=10, required=False)
             # Reference water threshold value for dark land candidates
             water_threshold: num(min=0, max=100, required=False)
+            minimum_pixel: num(min=0, required=False)
 
         refine_with_bimodality:
             number_cpu: num(required=False)

--- a/src/dswx_sar/schemas/algorithm_parameter_s1.yaml
+++ b/src/dswx_sar/schemas/algorithm_parameter_s1.yaml
@@ -51,7 +51,7 @@ runconfig:
             # 2) min value and 3) max value of mean of subtiles / mean of tiles
             tile_selection_twele: list(required=False)
             # Thresholds to select tiles showing the boundary between water and nonwater
-            # using bimodality strategy. 
+            # using bimodality strategy.
             # One values are required for bimodality method
             tile_selection_bimodality: num(required=False)
             # Strategy to interpolate the tile-based thresholds.
@@ -66,8 +66,8 @@ runconfig:
             # estimate single threshold per tile. If True, the trimodal distribution is assumed,
             # the lowest threshold is estimated.
             multi_threshold: bool(required=False)
-            # Flag to average the thresholds within the tile. 
-            # The output thresholds are assigned to each tile. 
+            # Flag to average the thresholds within the tile.
+            # The output thresholds are assigned to each tile.
             tile_average: bool(required=False)
             number_iterations: num(required=False)
             # Number of threads to run
@@ -76,7 +76,7 @@ runconfig:
 
         fuzzy_value:
             line_per_block: num(min=1, required=False)
-            hand: 
+            hand:
                 # Min and max values for hand are automatically calculated
                 # from input HAND, but they are not given,
                 # below values are used.
@@ -86,14 +86,14 @@ runconfig:
             slope:
                 member_min: num(required=False)
                 member_max: num(required=False)
-            # Membership bound for reference water                
+            # Membership bound for reference water
             reference_water:
                 # Minimum reference water value for membership
                 member_min: num(required=False)
                 # Maximum reference water value for membership
                 member_max: num(required=False)
             # Membership bound for area of initial water bodies.
-            # Area membership is only required for 'twele' workflow. 
+            # Area membership is only required for 'twele' workflow.
             area:
                 member_min: num(required=False)
                 member_max: num(required=False)
@@ -111,7 +111,7 @@ runconfig:
                 water_min_value: num(required=False)
                 # Maximum value for high frequent water
                 water_max_value: num(required=False)
-                        
+
         region_growing:
             # Seed value for region growing start
             initial_threshold: num(min=0, max=1, required=False)
@@ -144,5 +144,5 @@ runconfig:
             cross_pol_min: num(min=-30, max=10, required=False)
             line_per_block: num(min=1, required=False)
 
-        # If debug mode is true, intermediate product is generated. 
+        # If debug mode is true, intermediate product is generated.
         debug_mode: bool(required=False)


### PR DESCRIPTION
This PR fixes bugs in the `masking ancillary` step. When `cv2.connectedComponentsWithStats` is applied, the number of the components could be larger than `65504`. Then, the remaining components could have `inf` value, then the error affects the remaining step.