### PR TITLE
Fix bug in mosaic burst

### DIFF
--- a/src/dswx_sar/dswx_sar_util.py
+++ b/src/dswx_sar/dswx_sar_util.py
@@ -300,7 +300,9 @@ def _save_as_cog(filename,
     shutil.move(temp_file, filename)
 
 
-def change_epsg_tif(input_tif, output_tif, epsg_output):
+def change_epsg_tif(input_tif, output_tif, epsg_output,
+                    resample_method='nearest',
+                    output_nodata='NaN'):
     """Resample the input geotiff image to new EPSG code.
     Parameters
     ----------
@@ -314,8 +316,8 @@ def change_epsg_tif(input_tif, output_tif, epsg_output):
     metadata = get_meta_from_tif(input_tif)
     opt = gdal.WarpOptions(
         dstSRS=f'EPSG:{epsg_output}',
-        resampleAlg='nearest',
-        dstNodata='Nan',
+        resampleAlg=resample_method,
+        dstNodata=output_nodata,
         xRes=metadata['geotransform'][1],
         yRes=metadata['geotransform'][5],
         format='GTIFF')

--- a/src/dswx_sar/mosaic_rtc_burst.py
+++ b/src/dswx_sar/mosaic_rtc_burst.py
@@ -725,6 +725,9 @@ def run(cfg):
 
     mosaic_mode = mosaic_cfg.mosaic_mode
     product_prefix = processing_cfg.mosaic.mosaic_prefix
+    pol_list = cfg.groups.processing.polarizations
+    first_pol = pol_list[0]
+
     imagery_extension = 'tif'
     os.makedirs(scratch_path, exist_ok=True)
 
@@ -752,8 +755,6 @@ def run(cfg):
     if mosaic_flag:
         print('Number of bursts to process:', num_input_path)
 
-        pol_list = cfg.groups.processing.polarizations
-
         freqA_path = '/data/'
 
         output_file_list = []
@@ -763,25 +764,45 @@ def run(cfg):
         epsg_list = []
 
         for ind, input_dir in enumerate(input_list):
-            # find HDF5 metadata
-            metadata_path = glob.glob(f'{input_dir}/*h5')[0]
-            epsg_list.append(read_metadata_epsg(metadata_path)['epsg'])
+
+            first_rtc_path_iter = glob.iglob(f'{input_dir}/*_{first_pol}*.tif')
+            first_rtc_path = next(first_rtc_path_iter)
+            if first_rtc_path:
+                rtc_meta = dswx_sar_util.get_meta_from_tif(first_rtc_path)
+                epsg_list.append(rtc_meta['epsg'])
+            else:
+                err_msg = 'RTC files not found.'
+                raise FileExistsError(err_msg)
 
         epsg_output = majority_element(epsg_list)
-
+        logger.info('All RTC bursts and associated masks will be mosaicked ',
+                    f'using the ESPG projection designated by {epsg_output}.')
         # for each directory, find metadata, and RTC files.
         for ind, input_dir in enumerate(input_list):
 
             # find HDF5 metadata
-            metadata_path = glob.glob(f'{input_dir}/*h5')[0]
-            metadata_list.append(metadata_path)
-
             layover_path = glob.glob(f'{input_dir}/*mask.tif')
+            temp_mask_path = f'{scratch_path}/layover_{ind}.tif'
+
             if len(layover_path) > 0:
-                mask_list.append(layover_path[0])
+                logger.info('Layover/shadow GeoTIFF is found.')
+                if epsg_output != epsg_list[ind]:
+                    logger.info(f'{layover_path[0]}, {epsg_list[ind]} -> {epsg_output}')
+                    dswx_sar_util.change_epsg_tif(
+                        input_tif=layover_path,
+                        output_tif=temp_mask_path,
+                        epsg_output=epsg_output,
+                        output_nodata=255)
+
+                    mask_list.append(temp_mask_path)
+                else:
+                    mask_list.append(layover_path[0])
+
             else:
-            # layover/shadow mask is saved from hdf5 metadata.
-                temp_mask_path = f'{scratch_path}/layover_{ind}.tif'
+                metadata_path = glob.glob(f'{input_dir}/*h5')[0]
+                # layover/shadow mask is saved from hdf5 metadata.
+                logger.info('Metadata HDF5 is found.')
+
                 with h5py.File(metadata_path) as meta_src:
                     if 'mask' in meta_src[freqA_path]:
                         mask_name = 'mask'
@@ -836,17 +857,17 @@ def run(cfg):
                         mosaic_mode, scratch_dir=scratch_path,
                         geogrid_in=None, temp_files_list=None)
 
-        geo_mask_filename = \
-            (f'{output_dir_mosaic_raster}/{product_prefix}_layovershadow_mask.'
-                f'{imagery_extension}')
-        logger.info(f'    {geo_mask_filename}')
-        output_file_list.append(geo_mask_filename)
-
-        mosaic_single_output_file(
-            mask_list, nlooks_list, geo_mask_filename,
-            mosaic_mode, scratch_dir=scratch_path,
-            geogrid_in=None, temp_files_list=None,
-            no_data_value=255)
+        if mask_list:
+            geo_mask_filename = \
+                (f'{output_dir_mosaic_raster}/{product_prefix}_layovershadow_mask.'
+                    f'{imagery_extension}')
+            logger.info(f'    {geo_mask_filename}')
+            output_file_list.append(geo_mask_filename)
+            mosaic_single_output_file(
+                mask_list, nlooks_list, geo_mask_filename,
+                mosaic_mode, scratch_dir=scratch_path,
+                geogrid_in=None, temp_files_list=None,
+                no_data_value=255)
 
         # save files as COG format.
         if processing_cfg.mosaic.mosaic_cog_enable:

--- a/src/dswx_sar/mosaic_rtc_burst.py
+++ b/src/dswx_sar/mosaic_rtc_burst.py
@@ -765,7 +765,7 @@ def run(cfg):
 
         for ind, input_dir in enumerate(input_list):
 
-            first_rtc_path_iter = glob.iglob(f'{input_dir}/*_{first_pol}*.tif')
+            first_rtc_path_iter = glob.iglob(f'{input_dir}/*_{first_pol}.tif')
             first_rtc_path = next(first_rtc_path_iter)
             if first_rtc_path:
                 rtc_meta = dswx_sar_util.get_meta_from_tif(first_rtc_path)
@@ -783,7 +783,8 @@ def run(cfg):
             # find HDF5 metadata
             layover_path = glob.glob(f'{input_dir}/*mask.tif')
             temp_mask_path = f'{scratch_path}/layover_{ind}.tif'
-
+            # If both `*_mask.tif` and `*.h5` exists in RTC-S1 burst product directory:
+            # The metadata in `*_mask.tif` has priority over HDF5 file.
             if len(layover_path) > 0:
                 logger.info('Layover/shadow GeoTIFF is found.')
                 if epsg_output != epsg_list[ind]:

--- a/src/dswx_sar/mosaic_rtc_burst.py
+++ b/src/dswx_sar/mosaic_rtc_burst.py
@@ -793,14 +793,14 @@ def run(cfg):
                         output_tif=temp_mask_path,
                         epsg_output=epsg_output,
                         output_nodata=255)
-
                     mask_list.append(temp_mask_path)
                 else:
                     mask_list.append(layover_path[0])
 
             else:
+                # If mask GeoTiff is not available,
+                # layover/shadow mask may be saved in hdf5 metadata.
                 metadata_path = glob.glob(f'{input_dir}/*h5')[0]
-                # layover/shadow mask is saved from hdf5 metadata.
                 logger.info('Metadata HDF5 is found.')
 
                 with h5py.File(metadata_path) as meta_src:
@@ -860,7 +860,7 @@ def run(cfg):
         if mask_list:
             geo_mask_filename = \
                 (f'{output_dir_mosaic_raster}/{product_prefix}_layovershadow_mask.'
-                    f'{imagery_extension}')
+                 f'{imagery_extension}')
             logger.info(f'    {geo_mask_filename}')
             output_file_list.append(geo_mask_filename)
             mosaic_single_output_file(


### PR DESCRIPTION
This PR fixes the issue in `mosaic_rtc_burst.py`. The problem occurred when the RTC bursts have different EPSG codes in `layover/shadow masks`. The previous version did not handle the issue. 
This PR adds the lines to relocate the mask GeoTIFF with the majority of the EPSG code and perform the mosaicking method. 