### PR TITLE
Change ancillary ext

### DIFF
--- a/src/dswx_sar/detect_inundated_vegetation.py
+++ b/src/dswx_sar/detect_inundated_vegetation.py
@@ -72,7 +72,7 @@ def run(cfg):
 
     # Currently, inundated vegetation for C-band is available for
     # Herbanceous wetland area
-    landcover_path_str = os.path.join(outputdir, 'interpolated_landcover')
+    landcover_path_str = os.path.join(outputdir, 'interpolated_landcover.tif')
     mask_obj = FillMaskLandCover(landcover_path_str)
     target_inundated_vege_class = mask_obj.get_mask(
         mask_label=['Herbaceous wetland'])

--- a/src/dswx_sar/fuzzy_value_computation.py
+++ b/src/dswx_sar/fuzzy_value_computation.py
@@ -329,8 +329,6 @@ def compute_fuzzy_value(intensity,
         else:
             change_ind = co_pol_ind
 
-        logger.info('Cross pol is replaced with co-pol and span '
-                    'over the controversial area')
         # Cross-polarization intensity is replaced with co- (or span-) polarizations
         # where water varation is high and areas are dark/flat.
         intensity_z_set[cross_pol_ind][high_frequent_water] = \
@@ -350,25 +348,15 @@ def compute_fuzzy_value(intensity,
     nansum_intensity_z_set = np.squeeze(np.nansum(intensity_z_set, axis=0))
 
     # Compute HAND membership
-    logger.info('compute hand z membership')
     hand[np.isnan(hand)] = 0
-    logger.info(f"     {fuzzy_option['hand_min']} {fuzzy_option['hand_max']}"
-                " are used to compute HAND membership")
-
     hand_z = zmf(hand, fuzzy_option['hand_min'], fuzzy_option['hand_max'])
 
     # compute slope membership
-    logger.info('compute slope z membership')
-    logger.info(f"      {fuzzy_option['slope_min']} {fuzzy_option['slope_max']}"
-                " are used to compute slope membership")
     slope_z = zmf(slope,
                   fuzzy_option['slope_min'],
                   fuzzy_option['slope_max'])
 
     # Compute area membership
-    logger.info('area s membership')
-    logger.info(f"      {fuzzy_option['area_min']} {fuzzy_option['area_max']}"
-                " are used to compute area membership")
     handem = hand < fuzzy_option['hand_threshold']
     wbsmask = (initial_map == 1) & (handem)
     watermap = calculate_water_area(wbsmask)
@@ -377,9 +365,6 @@ def compute_fuzzy_value(intensity,
                 fuzzy_option['area_max'])
 
     # Reference water map membership
-    logger.info('reference s membership')
-    logger.info(f"      {fuzzy_option['reference_water_min']} {fuzzy_option['reference_water_max']}"
-                " are used to compute reference water membership")
     reference_water_s = smf(reference_water,
                             fuzzy_option['reference_water_min'],
                             fuzzy_option['reference_water_max'])
@@ -444,14 +429,31 @@ def run(cfg):
                    'high_frequent_water_max': fuzzy_cfg.high_frequent_water.water_max_value
     }
 
+
     workflow = processing_cfg.dswx_workflow
+
+    logger.info('compute slope z membership')
+    logger.info(f"      {option_dict['slope_min']} {option_dict['slope_max']}"
+                " are used to compute slope membership")
+
+    logger.info('reference s membership')
+    logger.info(f"      {option_dict['reference_water_min']} {option_dict['reference_water_max']}"
+                " are used to compute reference water membership")
+
+    logger.info('compute hand z membership')
+    logger.info(f"     {option_dict['hand_min']} {option_dict['hand_max']}"
+                " are used to compute HAND membership")
+
+    logger.info('area s membership')
+    logger.info(f"      {option_dict['area_min']} {option_dict['area_max']}"
+                " are used to compute area membership")
 
     filt_im_str = os.path.join(outputdir, f"filtered_image_{pol_all_str}.tif")
     dem_gdal_str = os.path.join(outputdir, 'interpolated_DEM.tif')
     hand_gdal_str = os.path.join(outputdir, 'interpolated_hand.tif')
     landcover_gdal_str = os.path.join(outputdir, 'interpolated_landcover.tif')
     reference_water_gdal_str = os.path.join(outputdir, 'interpolated_wbd.tif')
-    slope_gdal_str = os.path.join(outputdir, 'slope')
+    slope_gdal_str = os.path.join(outputdir, 'slope.tif')
 
     # Output of Fuzzy_computation
     fuzzy_output_str = os.path.join(

--- a/src/dswx_sar/fuzzy_value_computation.py
+++ b/src/dswx_sar/fuzzy_value_computation.py
@@ -447,10 +447,10 @@ def run(cfg):
     workflow = processing_cfg.dswx_workflow
 
     filt_im_str = os.path.join(outputdir, f"filtered_image_{pol_all_str}.tif")
-    dem_gdal_str = os.path.join(outputdir, 'interpolated_DEM')
-    hand_gdal_str = os.path.join(outputdir, 'interpolated_hand')
-    landcover_gdal_str = os.path.join(outputdir, 'interpolated_landcover')
-    reference_water_gdal_str = os.path.join(outputdir, 'interpolated_wbd')
+    dem_gdal_str = os.path.join(outputdir, 'interpolated_DEM.tif')
+    hand_gdal_str = os.path.join(outputdir, 'interpolated_hand.tif')
+    landcover_gdal_str = os.path.join(outputdir, 'interpolated_landcover.tif')
+    reference_water_gdal_str = os.path.join(outputdir, 'interpolated_wbd.tif')
     slope_gdal_str = os.path.join(outputdir, 'slope')
 
     # Output of Fuzzy_computation

--- a/src/dswx_sar/initial_threshold.py
+++ b/src/dswx_sar/initial_threshold.py
@@ -1653,7 +1653,7 @@ def run(cfg):
     height, width = filt_raster_tif.RasterYSize, filt_raster_tif.RasterXSize
 
     # READ relocated reference water
-    wbd_im_str = os.path.join(outputdir, 'interpolated_wbd')
+    wbd_im_str = os.path.join(outputdir, 'interpolated_wbd.tif')
     wbd_gdal = gdal.Open(wbd_im_str)
 
     # compute the statistics of intensity.

--- a/src/dswx_sar/masking_with_ancillary.py
+++ b/src/dswx_sar/masking_with_ancillary.py
@@ -531,12 +531,12 @@ def run(cfg):
     band_set = dswx_sar_util.read_geotiff(filt_im_str)
 
     # Reference water map
-    interp_wbd_str = os.path.join(outputdir, 'interpolated_wbd')
+    interp_wbd_str = os.path.join(outputdir, 'interpolated_wbd.tif')
     interp_wbd = dswx_sar_util.read_geotiff(interp_wbd_str)
     interp_wbd = np.array(interp_wbd, dtype='float32')
 
     # Worldcover map
-    landcover_path_str = os.path.join(outputdir, 'interpolated_landcover')
+    landcover_path_str = os.path.join(outputdir, 'interpolated_landcover.tif')
 
     # Identify target areas from landcover
     mask_obj = FillMaskLandCover(landcover_path_str)

--- a/src/dswx_sar/pre_processing.py
+++ b/src/dswx_sar/pre_processing.py
@@ -146,7 +146,7 @@ class AncillaryRelocation:
                                yRes=yspacing,
                                outputBounds=[W, S, E, N],
                                resampleAlg=method,
-                               format='ENVI')
+                               format='GTIFF')
 
         gdal.Warp(output_tif_str, input_tif_str, options=opt)
 
@@ -241,14 +241,14 @@ def run(cfg):
 
     # Check if the interpolated water body file exists
     wbd_interpolated_path = Path(os.path.join(scratch_dir,
-                                              'interpolated_wbd'))
+                                              'interpolated_wbd.tif'))
     if not wbd_interpolated_path.is_file():
         logger.info('interpolated wbd file was not found')
-        ancillary_reloc.relocate(wbd_file, 'interpolated_wbd', method='near')
+        ancillary_reloc.relocate(wbd_file, 'interpolated_wbd.tif', method='near')
 
     # Check if the interpolated DEM exists
     dem_interpolated_path = Path(os.path.join(scratch_dir,
-                                              'interpolated_DEM'))
+                                              'interpolated_DEM.tif'))
     dem_reprocessing_flag = False
     if not dem_interpolated_path.is_file():
         logger.info('interpolated dem : not found ')
@@ -256,7 +256,7 @@ def run(cfg):
         if os.path.isfile(dem_file):
             logger.info('interpolated dem file was not found')
             ancillary_reloc.relocate(dem_file,
-                                     'interpolated_DEM',
+                                     'interpolated_DEM.tif',
                                      method='near')
         else:
             raise FileNotFoundError
@@ -265,22 +265,22 @@ def run(cfg):
     if not dem_reprocessing_flag:
         dem_subset = dswx_sar_util.read_geotiff(
                         os.path.join(scratch_dir,
-                                     'interpolated_DEM'))
+                                     'interpolated_DEM.tif'))
         dem_mean = np.nanmean(dem_subset)
         if (dem_mean == 0) | np.isnan(dem_mean):
             raise ValueError
         del dem_subset
     # check if the interpolated landcover exists ###
     landcover_interpolated_path = Path(os.path.join(scratch_dir,
-                                                    'interpolated_landcover'))
+                                                    'interpolated_landcover.tif'))
     if not landcover_interpolated_path.is_file():
         ancillary_reloc.relocate(landcover_file,
-                                 'interpolated_landcover',
+                                 'interpolated_landcover.tif',
                                  method='near')
 
     # Check if the interpolated HAND exists
     hand_interpolated_path = os.path.join(scratch_dir,
-                                          'interpolated_hand')
+                                          'interpolated_hand.tif')
     if not os.path.isfile(hand_interpolated_path):
 
         # Check if compuated HAND exists
@@ -290,7 +290,7 @@ def run(cfg):
             # args.hand_file = os.path.join(args.scratch_dir, 'temp_hand.tif')
 
         ancillary_reloc.relocate(hand_file,
-                                 'interpolated_hand',
+                                 'interpolated_hand.tif',
                                  method='near')
 
     intensity = []

--- a/src/dswx_sar/refine_with_bimodality.py
+++ b/src/dswx_sar/refine_with_bimodality.py
@@ -1069,11 +1069,11 @@ def run(cfg):
     water_mask_image = dswx_sar_util.read_geotiff(water_map_tif_str)
 
     # read landcover map
-    landcover_map_tif_str = os.path.join(outputdir, 'interpolated_landcover')
+    landcover_map_tif_str = os.path.join(outputdir, 'interpolated_landcover.tif')
     landcover_map = dswx_sar_util.read_geotiff(landcover_map_tif_str)
     landcover_label = masking_with_ancillary.get_label_landcover_esa_10()
 
-    reference_water_gdal_str = os.path.join(outputdir, 'interpolated_wbd')
+    reference_water_gdal_str = os.path.join(outputdir, 'interpolated_wbd.tif')
 
     # Identify the non-water area from Landcover map
     if 'openSea' in landcover_label:

--- a/src/dswx_sar/save_mgrs_tiles.py
+++ b/src/dswx_sar/save_mgrs_tiles.py
@@ -553,7 +553,7 @@ def run(cfg):
 
     # 3) hand excluded
     hand = dswx_sar_util.read_geotiff(
-        os.path.join(outputdir, 'interpolated_hand'))
+        os.path.join(outputdir, 'interpolated_hand.tif'))
     hand_mask = hand > hand_mask
 
     full_wtr_water_set_path = \


### PR DESCRIPTION
This PR updates the file extension for ancillary data.

The ancillary files, which were previously relocated and saved in ENVI format, will now be stored in GeoTIFF format to prevent potential errors associated with the ENVI format.