### PR TITLE
hand filter and landcover extension

### DIFF
--- a/src/dswx_sar/defaults/algorithm_parameter_s1.yaml
+++ b/src/dswx_sar/defaults/algorithm_parameter_s1.yaml
@@ -126,15 +126,23 @@ runconfig:
             line_per_block: 400
 
         masking_ancillary:
+            # Land covers that behaves like dark lands in DSWx-SAR. 
+            # The elements should be in given landcover file. 
+            # The elements will be masked out during this step.
             land_cover_darkland_list: ['Bare sparse vegetation', 'Urban', 'Moss and lichen']
+            # The elements is considered as the dark land candidates
+            # where these elemtns are spatially connected to the dark land.
             land_cover_darkland_extension_list: ['Grassland', 'Shrubs']
             # VV and VH threshold values for dark land candidates
             co_pol_threshold: -14.6
             cross_pol_threshold: -22.8
             # reference water threshold value for dark land candidates
             water_threshold: 0.05
+            # Flag to enable the darkland extension.
             extended_darkland: True
+            # Flag to enable the HAND filter.
             hand_variation_mask: True
+            # pixels with HAND threshold is masked out.
             hand_variation_threshold: 2.5
             number_cpu: 1
 

--- a/src/dswx_sar/defaults/algorithm_parameter_s1.yaml
+++ b/src/dswx_sar/defaults/algorithm_parameter_s1.yaml
@@ -126,11 +126,16 @@ runconfig:
             line_per_block: 400
 
         masking_ancillary:
+            land_cover_darkland_list: ['Bare sparse vegetation', 'Urban', 'Moss and lichen']
+            land_cover_darkland_extension_list: ['Grassland', 'Shrubs']
             # VV and VH threshold values for dark land candidates
             co_pol_threshold: -14.6
             cross_pol_threshold: -22.8
             # reference water threshold value for dark land candidates
-            water_threshold:
+            water_threshold: 0.05
+            extended_darkland: True
+            hand_variation_mask: True
+            hand_variation_threshold: 2.5
             number_cpu: 1
 
         refine_with_bimodality:

--- a/src/dswx_sar/dswx_runconfig.py
+++ b/src/dswx_sar/dswx_runconfig.py
@@ -1,12 +1,12 @@
+import argparse
 from dataclasses import dataclass
+from functools import singledispatch
 import os
 import sys
 import logging
-from functools import singledispatch
 from types import SimpleNamespace
 
 import yamale
-import argparse
 from ruamel.yaml import YAML
 
 import dswx_sar
@@ -56,7 +56,8 @@ def _deep_update(original, update):
         if isinstance(val, dict):
             original[key] = _deep_update(original.get(key, {}), val)
         else:
-            original[key] = val
+            if val is not None:
+                original[key] = val
 
     # return updated original
     return original

--- a/src/dswx_sar/masking_with_ancillary.py
+++ b/src/dswx_sar/masking_with_ancillary.py
@@ -510,7 +510,29 @@ def extend_land_cover(landcover_path,
                       exclude_area_rg,
                       metainfo,
                       scratch_dir):
+    """
+    Extends the specified type of land cover within a geographical dataset.
 
+    Parameters:
+    -----------
+    landcover_path (str): 
+        Path to the land cover data file.
+    reference_landcover_binary (numpy.ndarray): 
+        Binary array representing the initial land cover.
+    target_landcover (int): 
+        Label of the land cover type to be extended.
+    exclude_area_rg (numpy.ndarray): 
+        Array representing areas to be excluded from processing.
+    metainfo (dict): 
+        Metadata including geotransform and projection information.
+    scratch_dir (str): 
+        Directory for saving intermediate and output files.
+
+    Returns:
+    --------
+    numpy.ndarray: 
+        Updated binary land cover array with the extended target land cover.
+    """
     mask_obj = FillMaskLandCover(landcover_path)
 
     mask_excluded_candidate = mask_obj.get_mask(
@@ -600,19 +622,43 @@ def extract_values_using_boundary(boundary_data, float_data):
     return data_array, float_data
 
 
-def estimate_height_variation(target_area,
+def hand_filter_along_boundary(target_area,
                               height_std_threshold,
                               hand_path,
                               debug_mode,
                               metainfo,
                               scratch_dir):
+    """
+    Filters geographic data along boundaries based on HAND model and 
+    standard deviation thresholds.
+
+    Parameters:
+    -----------
+    target_area : numpy.ndarray
+        Array representing the target area for filtering.
+    height_std_threshold : float
+        Standard deviation threshold for HAND values.
+    hand_path : str
+        Path to the HAND data file.
+    debug_mode : bool
+        Flag to activate debug mode for additional outputs.
+    metainfo : dict
+        Metadata including geotransform and projection information.
+    scratch_dir : str
+        Directory for saving debug outputs.
+
+    Returns:
+    --------
+    numpy.ndarray
+        Binary array representing the filtered HAND data.
+    """
     hand_obj = gdal.Open(hand_path)
 
     coord_lists, sizes, output_water = \
         extract_bbox_with_buffer(target_area, 10)
     nb_components_water = len(sizes)
     height_array = np.zeros(nb_components_water)
-    hand_std_binary = np.zeros(target_area.shape, dtype='byte')
+    hand_filtered_binary = np.zeros(target_area.shape, dtype='byte')
     hand_std_image = np.zeros(target_area.shape, dtype='float32')
     
     for ind, coord_list in enumerate(coord_lists):
@@ -627,20 +673,22 @@ def estimate_height_variation(target_area,
                                         sub_win_y)
         initial_area = sub_water_label == ind + 1
 
-        water_boundary = extract_boundary(np.array(sub_water_label == ind + 1, dtype='byte')
-                                          )
-        hand_line_data, hand_image_data = extract_values_using_boundary(water_boundary, sub_hand)
+        water_boundary = extract_boundary(
+            np.array(sub_water_label == ind + 1, dtype='byte'))
+        hand_line_data, hand_image_data = \
+            extract_values_using_boundary(water_boundary, sub_hand)
         hand_std = np.nanstd(hand_line_data)
         height_array[ind] = np.nanstd(hand_line_data)
 
         hand_std_image[sub_y_start:sub_y_end,
                        sub_x_start:sub_x_end] += hand_image_data
+    
         if hand_std > height_std_threshold:
             final_binary = np.zeros(sub_hand.shape, dtype='byte')
             area_median = np.median(hand_line_data)
             hand_threshold_erosion = area_median + hand_std * 1
             hand_image_mask = hand_image_data > hand_threshold_erosion
-            # final_binary[hand_image_data <= hand_threshold_erosion] = 1
+
             bad_hand_count = 1
             iter_count = 0
             while bad_hand_count > 0:
@@ -655,10 +703,10 @@ def estimate_height_variation(target_area,
                 initial_area = new_binary
                 iter_count += 1
             final_binary[new_binary==1] = 1
-            hand_std_binary[sub_y_start:sub_y_end,
+            hand_filtered_binary[sub_y_start:sub_y_end,
                     sub_x_start:sub_x_end] += final_binary
         else:
-            hand_std_binary[sub_y_start:sub_y_end,
+            hand_filtered_binary[sub_y_start:sub_y_end,
                     sub_x_start:sub_x_end] += initial_area
 
     output_water = np.array(output_water)
@@ -666,10 +714,7 @@ def estimate_height_variation(target_area,
     index_array_to_image = np.searchsorted(old_val, output_water)
     height_array =  np.insert(height_array, 0, 0, axis=0)
     height_std_raster = height_array[index_array_to_image]
-   # hand_std_binary[height_std_raster <= height_std_threshold] = 1
-    # hand_std_binary[target_area == 0] = 0
-    # hand_std_binary[sub_y_start:sub_y_end,
-    #                 sub_x_start:sub_x_end] = final_binary
+
     if debug_mode:
         hand_std_path = os.path.join(
             scratch_dir, f"landcover_hand_std.tif")
@@ -692,7 +737,7 @@ def estimate_height_variation(target_area,
         hand_binary_path = os.path.join(
             scratch_dir, f"landcover_hand_bindary.tif")
         dswx_sar_util.save_dswx_product(
-            hand_std_binary,
+            hand_filtered_binary,
             hand_binary_path,
             geotransform=metainfo['geotransform'],
             projection=metainfo['projection'],
@@ -700,8 +745,7 @@ def estimate_height_variation(target_area,
             )
 
     del hand_obj
-    return hand_std_binary
-
+    return hand_filtered_binary
 
 
 def get_darkland_from_intensity(intensity_path,
@@ -709,6 +753,26 @@ def get_darkland_from_intensity(intensity_path,
                                 pol_list,
                                 co_pol_threshold,
                                 cross_pol_threshold):
+    """
+    Identifies low backscatter areas from SAR intensity data.
+
+    Parameters:
+    -----------
+    intensity_path (str): 
+        Path to the SAR intensity data file.
+    lines_per_block (int): 
+        Number of lines per block for processing.
+    pol_list (list): 
+        List of polarizations (e.g., ['VV', 'HH', 'VH', 'HV']).
+    co_pol_threshold (float): 
+        Threshold for co-polarized channels (e.g., 'VV', 'HH').
+    cross_pol_threshold (float): 
+        Threshold for cross-polarized channels (e.g., 'VH', 'HV').
+
+    Returns:
+    --------
+    numpy.ndarray: Boolean array indicating low backscatter areas.
+    """
     band_meta = dswx_sar_util.get_meta_from_tif(intensity_path)
     data_length = band_meta['length']
     data_width = band_meta['width']
@@ -731,7 +795,7 @@ def get_darkland_from_intensity(intensity_path,
         num_band = 1
         intensity_block = np.reshape(intensity_block, [num_band, cols, rows])
 
-    # 1) Identify low-backscattering areas
+    # Identify low-backscattering areas
     low_backscatter_cand = np.ones([cols, rows], dtype=bool)
     for pol_ind, pol in enumerate(pol_list):
         if pol in ['VV', 'HH']:
@@ -794,7 +858,7 @@ def run(cfg):
     # HAND
     hand_path_str = os.path.join(outputdir, 'interpolated_hand.tif')
     if hand_variation_mask:
-        hand_std_map = estimate_height_variation(
+        hand_std_map = hand_filter_along_boundary(
             water_map,
             hand_variation_threshold,
             hand_path_str,
@@ -892,7 +956,7 @@ def run(cfg):
     water_map[dark_land] = 0
 
     if hand_variation_mask:
-        hand_std_map = estimate_height_variation(
+        hand_std_map = hand_filter_along_boundary(
             water_map,
             hand_variation_threshold,
             hand_path_str,

--- a/src/dswx_sar/masking_with_ancillary.py
+++ b/src/dswx_sar/masking_with_ancillary.py
@@ -6,6 +6,7 @@ import time
 import cv2
 import numpy as np
 import rasterio
+from osgeo import gdal
 from joblib import Parallel, delayed
 from rasterio.windows import Window
 from scipy import ndimage
@@ -14,7 +15,8 @@ from typing import List, Tuple
 
 from dswx_sar import (dswx_sar_util,
                       generate_log,
-                      refine_with_bimodality)
+                      refine_with_bimodality,
+                      region_growing)
 from dswx_sar.dswx_runconfig import _get_parser, RunConfig
 
 
@@ -136,10 +138,10 @@ def extract_bbox_with_buffer(
         extra_buffer = max(extra_buffer, 1)
         buffer_all = extra_buffer + buffer
 
-        sub_x_start = max(0, x - buffer_all)
-        sub_y_start = max(0, y - buffer_all)
-        sub_x_end = min(cols, x + w + buffer_all)
-        sub_y_end = min(rows, y + h + buffer_all)
+        sub_x_start = int(max(0, x - buffer_all))
+        sub_y_start = int(max(0, y - buffer_all))
+        sub_x_end = int(min(cols, x + w + buffer_all))
+        sub_y_end = int(min(rows, y + h + buffer_all))
 
         coord_list.append([sub_x_start,
                            sub_x_end,
@@ -479,7 +481,10 @@ def compute_spatial_coverage(args):
         tuple: Tuple containing the index (i) and the test output (test_output_i).
     """
     i, size, threshold, bounds, water_label_str, ref_land_tif_str = args
-    row, col, width, height = bounds
+    row = bounds[0]
+    col = bounds[2]
+    width = bounds[1] - bounds[0]
+    height = bounds[3] - bounds[2]
     window = Window(row, col, width, height)
 
     # read subset of water map and intensity from given bounding box
@@ -499,6 +504,249 @@ def compute_spatial_coverage(args):
     return i, test_output_i
 
 
+def extend_land_cover(landcover_path,
+                      reference_landcover_binary,
+                      target_landcover,
+                      exclude_area_rg,
+                      metainfo,
+                      scratch_dir):
+
+    mask_obj = FillMaskLandCover(landcover_path)
+
+    mask_excluded_candidate = mask_obj.get_mask(
+        mask_label=target_landcover)
+
+    new_landcover = np.zeros(
+        reference_landcover_binary.shape,
+        dtype='float32')
+
+    new_landcover[reference_landcover_binary] = 1
+    new_landcover[mask_excluded_candidate] = 0.75
+
+    excluded_rg_path = os.path.join(
+        scratch_dir, f"landcover_excluded_rg.tif")
+    dswx_sar_util.save_dswx_product(
+        exclude_area_rg,
+        excluded_rg_path,
+        geotransform=metainfo['geotransform'],
+        projection=metainfo['projection'],
+        description='Water classification (WTR)',
+        scratch_dir=scratch_dir
+        )
+
+    darkland_tif_str = os.path.join(
+        scratch_dir, f"landcover_target.tif")
+    dswx_sar_util.save_dswx_product(
+        reference_landcover_binary,
+        darkland_tif_str,
+        geotransform=metainfo['geotransform'],
+        projection=metainfo['projection'],
+        description='Water classification (WTR)',
+        scratch_dir=scratch_dir
+        )
+
+    darkland_cand_tif_str = os.path.join(
+        scratch_dir, f"landcover_target_candidate.tif")
+    dswx_sar_util.save_raster_gdal(
+        np.array(new_landcover, dtype='float32'),
+        darkland_cand_tif_str,
+        geotransform=metainfo['geotransform'],
+        projection=metainfo['projection'],
+        scratch_dir=scratch_dir,
+        datatype='float32')
+
+    temp_rg_tif_path = os.path.join(
+        scratch_dir, f'landcover_temp_transition.tif')
+
+    region_growing.run_parallel_region_growing(
+        darkland_cand_tif_str,
+        temp_rg_tif_path,
+        exclude_area_path=excluded_rg_path,
+        lines_per_block=1000,
+        initial_threshold=0.9,
+        relaxed_threshold=0.7,
+        maxiter=0)
+
+    fuzzy_map = dswx_sar_util.read_geotiff(darkland_cand_tif_str)
+    temp_rg = dswx_sar_util.read_geotiff(temp_rg_tif_path)
+
+    # replace the fuzzy values with 1 for the pixels
+    # where the region-growing already applied
+    fuzzy_map[temp_rg == 1] = 1
+
+    # Run region-growing again for entire image
+    region_grow_map = region_growing.region_growing(
+        fuzzy_map,
+        initial_threshold=0.9,
+        relaxed_threshold=0.7,
+        maxiter=0)
+    reference_landcover_binary[region_grow_map] = 1
+
+    return reference_landcover_binary
+
+
+def extract_boundary(binary_data):
+    """Extracts the boundary of a binary image."""
+    # Dilate the binary data and then subtract the original data.
+    erosion = ndimage.binary_erosion(binary_data)
+    return np.bitwise_xor(binary_data, erosion)
+
+
+def extract_values_using_boundary(boundary_data, float_data):
+    """Extracts values from float_data where boundary_data is 1."""
+    data_array = float_data[boundary_data == 1]
+    float_data[boundary_data == 0] = 0
+
+    return data_array, float_data
+
+
+def estimate_height_variation(target_area,
+                              height_std_threshold,
+                              hand_path,
+                              debug_mode,
+                              metainfo,
+                              scratch_dir):
+    hand_obj = gdal.Open(hand_path)
+
+    coord_lists, sizes, output_water = \
+        extract_bbox_with_buffer(target_area, 10)
+    nb_components_water = len(sizes)
+    height_array = np.zeros(nb_components_water)
+    hand_std_binary = np.zeros(target_area.shape, dtype='byte')
+    hand_std_image = np.zeros(target_area.shape, dtype='float32')
+    
+    for ind, coord_list in enumerate(coord_lists):
+        sub_x_start, sub_x_end, sub_y_start, sub_y_end = coord_list
+        sub_win_x = int(sub_x_end - sub_x_start)
+        sub_win_y = int(sub_y_end - sub_y_start)
+        sub_water_label = output_water[sub_y_start:sub_y_end,
+                                       sub_x_start:sub_x_end]
+        sub_hand = hand_obj.ReadAsArray(sub_x_start,
+                                        sub_y_start,
+                                        sub_win_x,
+                                        sub_win_y)
+        initial_area = sub_water_label == ind + 1
+
+        water_boundary = extract_boundary(np.array(sub_water_label == ind + 1, dtype='byte')
+                                          )
+        hand_line_data, hand_image_data = extract_values_using_boundary(water_boundary, sub_hand)
+        hand_std = np.nanstd(hand_line_data)
+        height_array[ind] = np.nanstd(hand_line_data)
+
+        hand_std_image[sub_y_start:sub_y_end,
+                       sub_x_start:sub_x_end] += hand_image_data
+        if hand_std > height_std_threshold:
+            final_binary = np.zeros(sub_hand.shape, dtype='byte')
+            area_median = np.median(hand_line_data)
+            hand_threshold_erosion = area_median + hand_std * 1
+            hand_image_mask = hand_image_data > hand_threshold_erosion
+            # final_binary[hand_image_data <= hand_threshold_erosion] = 1
+            bad_hand_count = 1
+            iter_count = 0
+            while bad_hand_count > 0:
+                new_binary = ndimage.binary_erosion(
+                    initial_area,
+                    mask=hand_image_mask)
+                new_bound = extract_boundary(new_binary)
+                hand_line_data, hand_image_data = \
+                    extract_values_using_boundary(new_bound, sub_hand)
+                hand_image_mask = hand_image_data > hand_threshold_erosion
+                bad_hand_count = np.sum(hand_image_mask)
+                initial_area = new_binary
+                iter_count += 1
+            final_binary[new_binary==1] = 1
+            hand_std_binary[sub_y_start:sub_y_end,
+                    sub_x_start:sub_x_end] += final_binary
+        else:
+            hand_std_binary[sub_y_start:sub_y_end,
+                    sub_x_start:sub_x_end] += initial_area
+
+    output_water = np.array(output_water)
+    old_val = np.arange(1, nb_components_water + 1) - .1
+    index_array_to_image = np.searchsorted(old_val, output_water)
+    height_array =  np.insert(height_array, 0, 0, axis=0)
+    height_std_raster = height_array[index_array_to_image]
+   # hand_std_binary[height_std_raster <= height_std_threshold] = 1
+    # hand_std_binary[target_area == 0] = 0
+    # hand_std_binary[sub_y_start:sub_y_end,
+    #                 sub_x_start:sub_x_end] = final_binary
+    if debug_mode:
+        hand_std_path = os.path.join(
+            scratch_dir, f"landcover_hand_std.tif")
+        dswx_sar_util.save_raster_gdal(
+            np.array(height_std_raster, dtype='float32'),
+            hand_std_path,
+            geotransform=metainfo['geotransform'],
+            projection=metainfo['projection'],
+            scratch_dir=scratch_dir,
+            datatype='float32')
+        hand_std_path = os.path.join(
+            scratch_dir, f"landcover_hand_std_image.tif")
+        dswx_sar_util.save_raster_gdal(
+            np.array(hand_std_image, dtype='float32'),
+            hand_std_path,
+            geotransform=metainfo['geotransform'],
+            projection=metainfo['projection'],
+            scratch_dir=scratch_dir,
+            datatype='float32')
+        hand_binary_path = os.path.join(
+            scratch_dir, f"landcover_hand_bindary.tif")
+        dswx_sar_util.save_dswx_product(
+            hand_std_binary,
+            hand_binary_path,
+            geotransform=metainfo['geotransform'],
+            projection=metainfo['projection'],
+            scratch_dir=scratch_dir
+            )
+
+    del hand_obj
+    return hand_std_binary
+
+
+
+def get_darkland_from_intensity(intensity_path,
+                                lines_per_block,
+                                pol_list,
+                                co_pol_threshold,
+                                cross_pol_threshold):
+    band_meta = dswx_sar_util.get_meta_from_tif(intensity_path)
+    data_length = band_meta['length']
+    data_width = band_meta['width']
+    data_shape = [data_length, data_width]
+
+    pad_shape = (0, 0)
+    block_params = dswx_sar_util.block_param_generator(
+        lines_per_block,
+        data_shape,
+        pad_shape)
+
+    for block_param in block_params:
+        intensity_block = dswx_sar_util.get_raster_block(
+            intensity_path, block_param)
+    
+    if band_meta['band_number'] < 3:
+        num_band, cols, rows = np.shape(intensity_block)
+    else:
+        cols, rows = np.shape(intensity_block)
+        num_band = 1
+        intensity_block = np.reshape(intensity_block, [num_band, cols, rows])
+
+    # 1) Identify low-backscattering areas
+    low_backscatter_cand = np.ones([cols, rows], dtype=bool)
+    for pol_ind, pol in enumerate(pol_list):
+        if pol in ['VV', 'HH']:
+            pol_threshold = co_pol_threshold
+        elif pol in ['VH', 'HV']:
+            pol_threshold = cross_pol_threshold
+        else:
+            continue  # Skip unknown polarizations
+        low_backscatter = 10 * np.log10(intensity_block[pol_ind, :, :]) < pol_threshold
+        low_backscatter_cand = np.logical_and(low_backscatter,
+                                              low_backscatter_cand)
+
+    return low_backscatter_cand
+
+
 def run(cfg):
     '''
     Remove the false water which have low backscattering based on the
@@ -515,11 +763,19 @@ def run(cfg):
 
     water_cfg = processing_cfg.reference_water
     ref_water_max = water_cfg.max_value
+    ref_no_data = water_cfg.no_data_value
+
+    # options for masking with ancillary data
     masking_ancillary_cfg = processing_cfg.masking_ancillary
     number_workers = masking_ancillary_cfg.number_cpu
 
-    landcover_cfg = processing_cfg.masking_ancillary
-
+    dry_water_area_threshold = masking_ancillary_cfg.water_threshold
+    extended_landcover_flag = masking_ancillary_cfg.extended_darkland
+    hand_variation_mask = masking_ancillary_cfg.hand_variation_mask
+    hand_variation_threshold = masking_ancillary_cfg.hand_variation_threshold
+    landcover_masking_list = masking_ancillary_cfg.land_cover_darkland_list
+    landcover_masking_extension_list = masking_ancillary_cfg.land_cover_darkland_extension_list
+  
     # Binary water map extracted from region growing
     water_map_tif_str = os.path.join(
         outputdir, f'region_growing_output_binary_{pol_str}.tif')
@@ -535,16 +791,42 @@ def run(cfg):
     interp_wbd = dswx_sar_util.read_geotiff(interp_wbd_str)
     interp_wbd = np.array(interp_wbd, dtype='float32')
 
+    # HAND
+    hand_path_str = os.path.join(outputdir, 'interpolated_hand.tif')
+    if hand_variation_mask:
+        hand_std_map = estimate_height_variation(
+            water_map,
+            hand_variation_threshold,
+            hand_path_str,
+            debug_mode=processing_cfg.debug_mode,
+            metainfo=water_meta,
+            scratch_dir=outputdir)
+
     # Worldcover map
-    landcover_path_str = os.path.join(outputdir, 'interpolated_landcover.tif')
+    landcover_path = os.path.join(outputdir, 'interpolated_landcover.tif')
 
     # Identify target areas from landcover
-    mask_obj = FillMaskLandCover(landcover_path_str)
-    mask_excluded_landcover = mask_obj.get_mask(mask_label=['Bare sparse vegetation',
-                                                  'Urban',
-                                                  'Moss and lichen'])
+    mask_obj = FillMaskLandCover(landcover_path)
+    mask_excluded_landcover = mask_obj.get_mask(
+        mask_label=landcover_masking_list)
+
+    if extended_landcover_flag:
+        logger.info('Extending landcover enabled.')
+        rg_excluded_area = (interp_wbd>dry_water_area_threshold)
+        # if hand_variation_mask:
+        #     rg_excluded_area = rg_excluded_area | (hand_std_map == 1)
+
+        mask_excluded_landcover = extend_land_cover(
+            landcover_path=landcover_path,
+            reference_landcover_binary=mask_excluded_landcover,
+            target_landcover=landcover_masking_extension_list,
+            exclude_area_rg=rg_excluded_area,
+            metainfo=water_meta,
+            scratch_dir=outputdir)
+        logger.info('Landcover extension completed.')
+
     input_file_dict = {'intensity': filt_im_str,
-                       'landcover': landcover_path_str,
+                       'landcover': landcover_path,
                        'reference_water': interp_wbd_str,
                        'water_mask': water_map_tif_str}
 
@@ -559,9 +841,9 @@ def run(cfg):
     low_backscatter_cand = np.ones([cols, rows], dtype=bool)
     for pol_ind, pol in enumerate(pol_list):
         if pol in ['VV', 'HH']:
-            pol_threshold = landcover_cfg.co_pol_threshold
+            pol_threshold = masking_ancillary_cfg.co_pol_threshold
         elif pol in ['VH', 'HV']:
-            pol_threshold = landcover_cfg.cross_pol_threshold
+            pol_threshold = masking_ancillary_cfg.cross_pol_threshold
         else:
             continue  # Skip unknown polarizations
         low_backscatter = 10 * np.log10(band_set[pol_ind, :, :]) < pol_threshold
@@ -575,7 +857,7 @@ def run(cfg):
     # 3: low backscattering area
     # mask = intersect of landcover mask + no water + dark land
     mask_excluded = (mask_excluded_landcover) & \
-                    (interp_wbd / ref_water_max < 0.05) & \
+                    (interp_wbd / ref_water_max < dry_water_area_threshold) & \
                     (low_backscatter_cand)
 
     # 3) The water candidates extracted in the previous step (region growing)
@@ -609,8 +891,19 @@ def run(cfg):
 
     water_map[dark_land] = 0
 
-    water_tif_str = os.path.join(outputdir,
-                                 f"refine_landcover_binary_{pol_str}.tif")
+    if hand_variation_mask:
+        hand_std_map = estimate_height_variation(
+            water_map,
+            hand_variation_threshold,
+            hand_path_str,
+            debug_mode=processing_cfg.debug_mode,
+            metainfo=water_meta,
+            scratch_dir=outputdir)
+        water_map[hand_std_map == 0] = 0
+
+
+    water_tif_str = os.path.join(
+        outputdir, f"refine_landcover_binary_{pol_str}.tif")
     dswx_sar_util.save_dswx_product(
         water_map,
         water_tif_str,
@@ -621,6 +914,16 @@ def run(cfg):
         dark_land=dark_land)
 
     if processing_cfg.debug_mode:
+        excluded_path = os.path.join(
+            outputdir, f"landcover_exclude_{pol_str}.tif")
+        dswx_sar_util.save_dswx_product(
+            mask_excluded_landcover,
+            excluded_path,
+            geotransform=water_meta['geotransform'],
+            projection=water_meta['projection'],
+            description='Water classification (WTR)',
+            scratch_dir=outputdir
+            )
 
         darkland_tif_str = os.path.join(outputdir,
                                         f"landcover_dark_land_binary_{pol_str}.tif")
@@ -644,8 +947,8 @@ def run(cfg):
             scratch_dir=outputdir
             )
 
-        darkland_str = os.path.join(outputdir,
-                                    f"split_dark_land_candidate_{pol_str}.tif")
+        darkland_str = os.path.join(
+            outputdir, f"split_dark_land_candidate_{pol_str}.tif")
         dswx_sar_util.save_dswx_product(
             split_mask_water_raster,
             darkland_str,
@@ -655,8 +958,8 @@ def run(cfg):
             scratch_dir=outputdir,
             dark_land=dark_land)
 
-        darkland_str = os.path.join(outputdir,
-                                    f"dark_land_50_candidate_{pol_str}.tif")
+        darkland_str = os.path.join(
+            outputdir, f"dark_land_50_candidate_{pol_str}.tif")
         dswx_sar_util.save_dswx_product(
             mask_water_image,
             darkland_str,

--- a/src/dswx_sar/schemas/algorithm_parameter_s1.yaml
+++ b/src/dswx_sar/schemas/algorithm_parameter_s1.yaml
@@ -120,17 +120,26 @@ runconfig:
             line_per_block: num(min=1, required=False)
 
         masking_ancillary:
+            # Land covers that behaves like dark lands in DSWx-SAR. 
+            # The elements should be in given landcover file. 
+            # The elements will be masked out during this step.
+            land_cover_darkland_list: list(required=False)
+            # The elements is considered as the dark land candidates
+            # where these elemtns are spatially connected to the dark land.
+            land_cover_darkland_extension_list: list(required=False)
             # VV and VH threshold values for dark land candidates
             co_pol_threshold: num(min=-30, max=10, required=False)
             cross_pol_threshold: num(min=-30, max=10, required=False)
             # Reference water threshold value for dark land candidates
             water_threshold: num(min=0, max=100, required=False)
             minimum_pixel: num(min=0, required=False)
+            # Flag to enable the darkland extension.
             extended_darkland: bool(required=False)
             # Assuming the height of the water/land boundaries has low
             # variation, the standard deviation is estimated along the boundaries
             # and removed if the std is high. 
             hand_variation_mask: bool(required=False)
+            # pixels with HAND threshold is masked out.
             hand_variation_threshold: num(min=0, max=100, required=False)
             number_cpu: num(required=False)
 

--- a/src/dswx_sar/schemas/algorithm_parameter_s1.yaml
+++ b/src/dswx_sar/schemas/algorithm_parameter_s1.yaml
@@ -126,6 +126,13 @@ runconfig:
             # Reference water threshold value for dark land candidates
             water_threshold: num(min=0, max=100, required=False)
             minimum_pixel: num(min=0, required=False)
+            extended_darkland: bool(required=False)
+            # Assuming the height of the water/land boundaries has low
+            # variation, the standard deviation is estimated along the boundaries
+            # and removed if the std is high. 
+            hand_variation_mask: bool(required=False)
+            hand_variation_threshold: num(min=0, max=100, required=False)
+            number_cpu: num(required=False)
 
         refine_with_bimodality:
             number_cpu: num(required=False)


### PR DESCRIPTION
This PR introduces the hand filter and landcover extension techniques. 

The `HAND filter` estimates the hand values along the water boundaries and detects the abnormal values from them, and erode the water bodies until all the values are within the conditions. 

The `landcover extension` extends the dark land areas. Previously, the dark land candidates are extracted from the `reference water`, `land cover`, and `low-backscattering`. However, some landcover may have different characteristics depending on the season. So, the new implementation is designed to extend the masking areas where the some land covers (i.e. grass land and Shrubs) are spatially connected to the `bare/sparse vegetation` under the assumption that the grass land or shrubs can behave like the dark lands. 