### PR TITLE
re-define the dark land areas

### DIFF
--- a/src/dswx_sar/fuzzy_value_computation.py
+++ b/src/dswx_sar/fuzzy_value_computation.py
@@ -281,8 +281,7 @@ def compute_fuzzy_value(intensity,
         if pol in ['VH', 'HV']:
             pol_threshold = fuzzy_option['dark_area_land']
             water_threshold = fuzzy_option['dark_area_water']
-            low_backscatter = (intensity[int_id, :, :] < pol_threshold) & \
-                              (intensity[int_id, :, :] > water_threshold)
+            low_backscatter = (intensity[int_id, :, :] < pol_threshold) 
             # Low backscattering candidates
             low_backscatter_cand &= low_backscatter
             dark_water_cand &= intensity[int_id, :, :] < water_threshold
@@ -308,6 +307,8 @@ def compute_fuzzy_value(intensity,
             (reference_water > fuzzy_option['high_frequent_water_min']) & \
             (reference_water < fuzzy_option['high_frequent_water_max']) & \
             (low_backscatter_cand)
+    dark_water = (dark_water_cand) & \
+                 (reference_water >= fuzzy_option['high_frequent_water_max'])
 
     co_pol_ind = []
     cross_pol_ind = []
@@ -338,8 +339,8 @@ def compute_fuzzy_value(intensity,
 
         # Co-polarization intensity is replaced with cross polarizations
         # where very dark water exists.
-        intensity_z_set[change_ind][dark_water_cand] = \
-            intensity_z_set[cross_pol_ind][dark_water_cand]
+        intensity_z_set[change_ind][dark_water] = \
+            intensity_z_set[cross_pol_ind][dark_water]
 
     copol_only = (high_frequent_water == 1) | \
                  (landcover_flat_area==1)


### PR DESCRIPTION
This PR updates the dark land areas. 
The dark land was extracted from several ancillary data. Since the only co-polarization image (i.e. VV) shows the boundary between the water and dark land, the algorithm selects the only co-polarization for fuzzy value computation without cross polarizations. This is because the cross-polarization does not show a distinct boundary. 

In contrast, the cross-pol is less affected by the bright-water issue. So, only a cross-polarization image is used to compute the fuzzy value where the areas are highly guaranteed.

The previous version was not clear in defining the dark land and water. This PR updates the dark land /water in fuzzy logic computation step.