### PR TITLE
modified the possible list for input polarizations

### DIFF
--- a/src/dswx_sar/defaults/algorithm_parameter_s1.yaml
+++ b/src/dswx_sar/defaults/algorithm_parameter_s1.yaml
@@ -8,7 +8,7 @@ runconfig:
         # [polarizations] for list of specific frequency(s) e.g. [VV, VH] or [VV]
         # 'dual-pol', 'co-pol', 'cross-pol' will search the polarizations Input GeoTiff files have. 
         # For example, 'co-pol' uses ['HH'], ['VV'], or ['HH', 'VV'] by looking at the input data. 
-        polarizations: ['VV', 'VH']
+        polarizations: ['dual-pol']
 
         # Specifiy the max_value for permanent water and no_data_value for invalid pixels
         reference_water:

--- a/src/dswx_sar/defaults/algorithm_parameter_s1.yaml
+++ b/src/dswx_sar/defaults/algorithm_parameter_s1.yaml
@@ -4,9 +4,10 @@ runconfig:
     processing:
         # dswx_workflow 'opera_dswx_s1', 'twele', 'opera_dswx_s1_inundated_vegetation'
         dswx_workflow: 'opera_dswx_s1'
-        # valid values for polarizations
-        # empty for all polarizations found in RSLC
-        # [polarizations] for list of specific frequency(s) e.g. [HH, HV] or [HH]
+        # Polarizations to be used for DSWx-SAR
+        # [polarizations] for list of specific frequency(s) e.g. [VV, VH] or [VV]
+        # 'dual-pol', 'co-pol', 'cross-pol' will search the polarizations Input GeoTiff files have. 
+        # For example, 'co-pol' uses ['HH'], ['VV'], or ['HH', 'VV'] by looking at the input data. 
         polarizations: ['VV', 'VH']
 
         # Specifiy the max_value for permanent water and no_data_value for invalid pixels

--- a/src/dswx_sar/detect_inundated_vegetation.py
+++ b/src/dswx_sar/detect_inundated_vegetation.py
@@ -21,8 +21,6 @@ def run(cfg):
     t_all = time.time()
 
     processing_cfg = cfg.groups.processing
-    pol_list = processing_cfg.polarizations
-    pol_all_str = '_'.join(pol_list)
     outputdir = cfg.groups.product_path_group.scratch_path
 
     pol_list = processing_cfg.polarizations

--- a/src/dswx_sar/detect_inundated_vegetation.py
+++ b/src/dswx_sar/detect_inundated_vegetation.py
@@ -91,7 +91,7 @@ def run(cfg):
     output_data[inundated_vegetation] = 2
     output_data[mask_excluded] = 0
 
-    inundated_vege_path = f"{outputdir}/temp_inundated_vegetation.tif"
+    inundated_vege_path = f"{outputdir}/temp_inundated_vegetation_{pol_all_str}.tif"
     dswx_sar_util.save_dswx_product(
         output_data,
         inundated_vege_path,
@@ -103,7 +103,8 @@ def run(cfg):
     if processing_cfg.debug_mode:
         dswx_sar_util.save_raster_gdal(
             data=filt_ratio_db,
-            output_file=os.path.join(outputdir, 'intensity_db_ratio.tif'),
+            output_file=os.path.join(outputdir,
+                                     f'intensity_db_ratio_{pol_all_str}.tif'),
             geotransform=im_meta['geotransform'],
             projection=im_meta['projection'],
             scratch_dir=outputdir)

--- a/src/dswx_sar/detect_inundated_vegetation.py
+++ b/src/dswx_sar/detect_inundated_vegetation.py
@@ -7,7 +7,7 @@ import numpy as np
 import osgeo.gdal as gdal
 
 from dswx_sar import dswx_sar_util, filter_SAR, generate_log
-from dswx_sar.dswx_runconfig import _get_parser, RunConfig
+from dswx_sar.dswx_runconfig import DSWX_S1_POL_DICT, _get_parser, RunConfig
 from dswx_sar.pre_processing import pol_ratio
 from dswx_sar.masking_with_ancillary import FillMaskLandCover
 
@@ -132,8 +132,21 @@ def main():
     if flag_first_file_is_text:
         cfg = RunConfig.load_from_yaml(args.input_yaml[0], 'dswx_s1', args)
 
-    run(cfg)
+    processing_cfg = cfg.groups.processing
+    pol_mode = processing_cfg.polarization_mode
+    pol_list = processing_cfg.polarizations
+    if pol_mode == 'MIX_DUAL_POL':
+        proc_pol_set = [DSWX_S1_POL_DICT['DV_POL'],
+                        DSWX_S1_POL_DICT['DH_POL']]
+    elif pol_mode == 'MIX_SINGLE_POL':
+        proc_pol_set = [DSWX_S1_POL_DICT['SV_POL'],
+                        DSWX_S1_POL_DICT['SH_POL']]
+    else:
+        proc_pol_set = [pol_list]
 
+    for pol_set in proc_pol_set:
+        processing_cfg.polarizations = pol_set
+        run(cfg)
 
 if __name__ == '__main__':
     main()

--- a/src/dswx_sar/dswx_geogrid.py
+++ b/src/dswx_sar/dswx_geogrid.py
@@ -1,0 +1,136 @@
+
+from dataclasses import dataclass
+
+import numpy as np
+from osgeo import osr, gdal
+
+
+@dataclass
+class DSWXGeogrid:
+    """
+    A dataclass representing the geographical grid configuration
+    for an RTC (Radar Terrain Correction) run.
+
+    Attributes:
+    -----------
+    start_x : float
+        The starting x-coordinate of the grid.
+    start_y : float
+        The starting y-coordinate of the grid.
+    end_x : float
+        The ending x-coordinate of the grid.
+    end_y : float
+        The ending y-coordinate of the grid.
+    spacing_x : float
+        The spacing between points in the x-direction.
+    spacing_y : float
+        The spacing between points in the y-direction.
+    length : int
+        The number of points in the y-direction.
+    width : int
+        The number of points in the x-direction.
+    epsg : int
+        The EPSG code representing the coordinate reference system of the grid.
+    """
+    start_x : float = np.nan
+    start_y : float = np.nan
+    end_x : float = np.nan
+    end_y : float = np.nan
+    spacing_x : float = np.nan
+    spacing_y : float = np.nan
+    length : int = np.nan
+    width : int = np.nan
+    epsg : int = np.nan
+
+    def get_geogrid_from_geotiff(self,
+                                 geotiff_path):
+        """
+        Extract geographical grid parameters from a GeoTIFF file
+        and update the dataclass attributes.
+
+        Parameters:
+        -----------
+        geotiff_path : str
+            The file path to the GeoTIFF file from which the grid
+            parameters are to be extracted.
+        """
+        tif_gdal = gdal.Open(geotiff_path)
+        geotransform = tif_gdal.GetGeoTransform()
+        self.start_x = geotransform[0]
+        self.spacing_x = geotransform[1]
+
+        self.start_y = geotransform[3]
+        self.spacing_y = geotransform[5]
+
+        self.length = tif_gdal.RasterYSize
+        self.width = tif_gdal.RasterXSize
+
+        self.end_x = self.start_x + self.width * self.spacing_x
+        self.end_y = self.start_y + self.length * self.spacing_y
+
+        projection = tif_gdal.GetProjection()
+        proj = osr.SpatialReference(wkt=projection)
+        output_epsg = proj.GetAttrValue('AUTHORITY',1)
+        self.epsg = int(output_epsg)
+        tif_gdal = None
+        del tif_gdal
+
+    @classmethod
+    def from_geotiff(cls, geotiff_path):
+        """
+        Extract geographical grid parameters from a GeoTIFF file
+        and update the dataclass attributes.
+        Parameters:
+        -----------
+        geotiff_path : str
+            The file path to the GeoTIFF file from which the grid
+            parameters are to be extracted.
+        """
+        tif_gdal = gdal.Open(geotiff_path)
+        geotransform = tif_gdal.GetGeoTransform()
+        start_x, spacing_x, _, start_y, _, spacing_y = geotransform
+        length = tif_gdal.RasterYSize
+        width = tif_gdal.RasterXSize
+        end_x = start_x + width * spacing_x
+        end_y = start_y + length * spacing_y
+        projection = tif_gdal.GetProjection()
+        proj = osr.SpatialReference(wkt=projection)
+        output_epsg = proj.GetAttrValue('AUTHORITY',1)
+        epsg = int(output_epsg)
+        tif_gdal = None
+        del tif_gdal
+        return cls(start_x, start_y, end_x, end_y, spacing_x, spacing_y,
+                   length, width, epsg)
+
+
+    def update_geogrid(self, geotiff_path):
+        """
+        Update the existing geographical grid parameters based on a new
+        GeoTIFF file, extending the grid to encompass both the existing
+        and new grid areas.
+        """
+        new_geogrid = DSWXGeogrid.from_geotiff(geotiff_path)
+
+        if self.epsg != new_geogrid.epsg and not np.isnan(self.epsg):
+            raise ValueError("EPSG codes of the existing and new geogrids do not match.")
+        self.start_x = min(filter(lambda x: not np.isnan(x), [self.start_x, new_geogrid.start_x]))
+        self.end_x = max(filter(lambda x: not np.isnan(x), [self.end_x, new_geogrid.end_x]))
+
+        if self.spacing_y > 0 or np.isnan(self.spacing_y):
+            self.end_y = max(filter(lambda x: not np.isnan(x), [self.end_y, new_geogrid.end_y]))
+            self.start_y = min(filter(lambda x: not np.isnan(x), [self.start_y, new_geogrid.start_y]))
+        else:
+            self.start_y = max(filter(lambda x: not np.isnan(x), [self.start_y, new_geogrid.start_y]))
+            self.end_y = min(filter(lambda x: not np.isnan(x), [self.end_y, new_geogrid.end_y]))
+
+        self.spacing_x = new_geogrid.spacing_x if not np.isnan(new_geogrid.spacing_x) else self.spacing_x
+        self.spacing_y = new_geogrid.spacing_y if not np.isnan(new_geogrid.spacing_y) else self.spacing_y
+
+        if not np.isnan(self.start_x) and not np.isnan(self.end_x) and not np.isnan(self.spacing_x):
+            self.width = int((self.end_x - self.start_x) / self.spacing_x)
+        
+        if not np.isnan(self.start_y) and not np.isnan(self.end_y) and not np.isnan(self.spacing_y):
+            self.length = int((self.end_y - self.start_y) / self.spacing_y)
+
+        self.epsg = new_geogrid.epsg if not np.isnan(new_geogrid.epsg) else self.epsg
+

--- a/src/dswx_sar/dswx_runconfig.py
+++ b/src/dswx_sar/dswx_runconfig.py
@@ -196,17 +196,36 @@ def _find_polarization_from_data(input_dir_list):
                     extracted_string = parts[-1].split('.')[0]
                     extracted_strings.append(extracted_string)
     found_pol = list(set(extracted_strings))
+    if not found_pol:
+        err_str = 'Failed to find polarizations from RTC files.'
+        raise ValueError(err_str)
     return found_pol
 
 
 def check_polarizations(pol_list, input_dir_list):
-    """Sort polarizations so that co-pols are preceded.
+    """
+    Sort polarizations so that co-polarizations are preceded. This function
+    identifies the common polarizations between the requested polarizations
+    and the ones available in the input directories. It then sorts them,
+    prioritizing co-polarizations (VV, HH) over cross-polarizations (VH, HV).
+
     Parameters
     ----------
     pol_list : list
         List of polarizations.
     input_dir_list : list
         List of the input directories with RTC GeoTIFF files.
+
+    Returns
+    -------
+    co_pol_list : list
+        List of co-polarizations present in both the request
+        and input directories.
+    cross_pol_list : list
+        List of cross-polarizations present in both the request and input
+        directories.
+    sorted_pol_list : list
+        List of all polarizations sorted, prioritizing co-polarizations.
     """
     actual_pol = _find_polarization_from_data(input_dir_list)
 

--- a/src/dswx_sar/dswx_s1.py
+++ b/src/dswx_sar/dswx_s1.py
@@ -14,7 +14,7 @@ from dswx_sar import (detect_inundated_vegetation,
                       region_growing,)
 from dswx_sar.dswx_runconfig import (_get_parser,
                                      RunConfig,
-                                     dswx_s1_pol_dict)
+                                     DSWX_S1_POL_DICT)
 from dswx_sar import generate_log
 
 logger = logging.getLogger('dswx_s1')
@@ -37,11 +37,11 @@ def dswx_s1_workflow(cfg):
     mosaic_rtc_burst.run(cfg)
 
     if pol_mode == 'MIX_DUAL_POL':
-        proc_pol_set = [dswx_s1_pol_dict['DV_POL'],
-                        dswx_s1_pol_dict['DH_POL']]
+        proc_pol_set = [DSWX_S1_POL_DICT['DV_POL'],
+                        DSWX_S1_POL_DICT['DH_POL']]
     elif pol_mode == 'MIX_SINGLE_POL':
-        proc_pol_set = [dswx_s1_pol_dict['SV_POL'],
-                        dswx_s1_pol_dict['SH_POL']]
+        proc_pol_set = [DSWX_S1_POL_DICT['SV_POL'],
+                        DSWX_S1_POL_DICT['SH_POL']]
     else:
         proc_pol_set = [pol_list]
 

--- a/src/dswx_sar/dswx_sar_util.py
+++ b/src/dswx_sar/dswx_sar_util.py
@@ -46,7 +46,7 @@ band_assign_value_conf_dict = {
 
 @dataclass
 class Constants:
-    # negligible number to avoid the zero-division warning. 
+    # negligible number to avoid the zero-division warning.
     negligible_value : float = 1e-5
 
 def get_interpreted_dswx_s1_ctable():
@@ -196,7 +196,7 @@ def save_dswx_product(wtr, output_file, geotransform,
             print(f'    {band_key.lower()} found {dswx_product_value}')
     gdal_type = np2gdal_conversion[str(datatype)]
 
-    gdal_ds = driver.Create(output_file, 
+    gdal_ds = driver.Create(output_file,
                             shape[1], shape[0], 1, gdal_type)
     gdal_ds.SetGeoTransform(geotransform)
     gdal_ds.SetProjection(projection)
@@ -335,10 +335,11 @@ def change_epsg_tif(input_tif, output_tif, epsg_output,
 def get_invalid_area(geotiff_path,
                      output_path=None,
                      geotransform=None,
-                     projection=None, 
+                     projection=None,
                      scratch_dir=None):
-    """get invalid areas (NaN) from GeoTiff and save it 
+    """get invalid areas (NaN) from GeoTiff and save it
     to new GeoTiff
+
     Parameters
     ----------
     geotiff_path: str
@@ -354,8 +355,8 @@ def get_invalid_area(geotiff_path,
     """
     image = read_geotiff(geotiff_path)
     if image.ndim == 3:
-        no_data_raster = np.isnan(
-            np.squeeze(image[0, :, :]))
+        no_data_raster = \
+            np.squeeze(np.nansum(image, axis=0)) == 0
     else:
         no_data_raster = np.isnan(image)
 
@@ -434,11 +435,11 @@ def get_raster_block(raster_path, block_param):
             block_param.read_start_line,
             block_param.data_width,
             block_param.read_length)
-        
+
         # Pad data_block with zeros according to pad_length/pad_width
-        data_block = np.pad(data_block, block_param.block_pad, 
+        data_block = np.pad(data_block, block_param.block_pad,
                             mode='constant', constant_values=0)
-        
+
         data_blocks.append(data_block)
     data_blocks = np.array(data_blocks)
 
@@ -646,14 +647,14 @@ def block_threshold_visulaization(intensity, block_row, block_col, threshold_til
     Parameters:
     -----------
     intensity : numpy.ndarray
-        A 2D or 3D array representing the intensity of the image. 
+        A 2D or 3D array representing the intensity of the image.
         If 3D, only the second and third dimensions (rows and columns) are used for visualization.
     block_row : int
         The number of rows in each block/subtile.
     block_col : int
         The number of columns in each block/subtile.
     threshold_tile : numpy.ndarray
-        2D array containing the threshold values for each block/subtile. 
+        2D array containing the threshold values for each block/subtile.
         Its dimensions should match the number of blocks in the intensity image.
     outputdir : str
         Path to the directory where visualizations will be saved.
@@ -665,18 +666,18 @@ def block_threshold_visulaization(intensity, block_row, block_col, threshold_til
     None. The visualized figure is saved to the specified directory.
     """
     if len(intensity.shape) == 2:
-        rows, cols = np.shape(intensity)  
+        rows, cols = np.shape(intensity)
     elif len(intensity.shape) == 3:
-        _, rows, cols = np.shape(intensity)  
+        _, rows, cols = np.shape(intensity)
     ## Tile Selection (w/o water body)
-    
-    nR = np.int16(rows / block_row) 
+
+    nR = np.int16(rows / block_row)
     nC = np.int16(cols / block_col)
     mR = np.mod(rows, block_row)
     mC = np.mod(cols, block_col)
-    nR = nR + ( 1 if mR > 0 else 0) 
-    nC = nC + ( 1 if mC > 0 else 0) 
-    
+    nR = nR + ( 1 if mR > 0 else 0)
+    nC = nC + ( 1 if mC > 0 else 0)
+
     assert nR == threshold_tile.shape[0], 'tile size error'
     assert nC == threshold_tile.shape[1], 'tile size error'
 
@@ -686,7 +687,7 @@ def block_threshold_visulaization(intensity, block_row, block_col, threshold_til
     vmin = np.nanpercentile(intensity,5)
     vmax = np.nanpercentile(intensity,95)
     plt.imshow(intensity, cmap = plt.get_cmap('gray'),vmin=vmin,vmax=vmax)
-       
+
     threshold_oversample = np.zeros([rows, cols])
     for ii in range(0,nR):
         for jj in range(0,nC):
@@ -697,9 +698,9 @@ def block_threshold_visulaization(intensity, block_row, block_col, threshold_til
             if (jj == nC) and ( mC > 0):
                 jend = cols
             else:
-                jend = (jj + 1) * block_col 
+                jend = (jj + 1) * block_col
             threshold_oversample[ii*block_row : iend, jj*block_col:jend] = threshold_tile[ii, jj]
-            plt.plot( 
+            plt.plot(
                 [jj*block_col,jend, jend, jj*block_col, jj*block_col],[ii*block_row, ii*block_row, iend, iend, ii*block_row] ,'black')
     threshold_oversample[threshold_oversample==-50] = np.nan
     plt.imshow(threshold_oversample, alpha=0.3, cmap = plt.get_cmap('jet'), vmin=-20, vmax=-14)
@@ -715,12 +716,12 @@ def block_threshold_visulaization_rg(intensity, threshold_dict, outputdir, figna
     Parameters:
     -----------
     intensity : numpy.ndarray
-        2D or 3D array representing the intensity of the image. 
+        2D or 3D array representing the intensity of the image.
         If 3D, the first dimension is considered as the band index.
     threshold_dict : dict
         A dictionary containing:
         * 'array': A nested list of threshold values for each band and block.
-        * 'subtile_coord': A nested list of block coordinates for each band and block, 
+        * 'subtile_coord': A nested list of block coordinates for each band and block,
           in the format [[start_row, end_row, start_col, end_col], ...].
     outputdir : str
         Path to the directory where visualizations will be saved.
@@ -745,24 +746,24 @@ def block_threshold_visulaization_rg(intensity, threshold_dict, outputdir, figna
         plt.figure(figsize=(20, 20))
         vmin = np.nanpercentile(intensity_db, 5)
         vmax = np.nanpercentile(intensity_db, 95)
-        
+
         # Display the main intensity image
         plt.imshow(intensity_db, cmap='gray', vmin=vmin, vmax=vmax)
-        
+
         # Prepare a matrix for the overlaid threshold values
         threshold_overlay = np.full((rows, cols), np.nan)
-        
+
         for threshold, coords in zip(threshold_dict['array'][band_index], threshold_dict['subtile_coord'][band_index]):
             start_row, end_row, start_col, end_col = coords
             threshold_overlay[start_row:end_row, start_col:end_col] = threshold
-            
+
             # Draw a block boundary for visualization
             plt.plot([start_col, end_col, end_col, start_col, start_col],
                      [start_row, start_row, end_row, end_row, start_row], 'black')
-        
+
         # Overlay the threshold values on top of the intensity image
         plt.imshow(threshold_overlay, alpha=0.3, cmap='jet', vmin=-20, vmax=-14)
-        
+
         # Save the visualization to file
         plt.savefig(os.path.join(outputdir, f'{figname}_{band_index}'))
         plt.close()

--- a/src/dswx_sar/fuzzy_value_computation.py
+++ b/src/dswx_sar/fuzzy_value_computation.py
@@ -91,8 +91,8 @@ def smf(values, minv, maxv):
     center_value = (minv + maxv) / 2
     output= np.zeros(np.shape(values), dtype='float32')
 
-    # When using numpy arrays for min and max values in 
-    # a membership function, identical elements in these 
+    # When using numpy arrays for min and max values in
+    # a membership function, identical elements in these
     # arrays are replaced with a slightly higher number
     # to avoid zero-division warnings.
     if isinstance(minv, np.ndarray):
@@ -135,8 +135,8 @@ def zmf(values, minv, maxv):
     '''
     output = np.zeros(np.shape(values))
 
-    # When using numpy arrays for min and max values in 
-    # a membership function, identical elements in these 
+    # When using numpy arrays for min and max values in
+    # a membership function, identical elements in these
     # arrays are replaced with a slightly higher number
     # to avoid zero-division warnings.
     if isinstance(minv, np.ndarray):
@@ -308,7 +308,7 @@ def compute_fuzzy_value(intensity,
         if pol in ['VH', 'HV']:
             pol_threshold = fuzzy_option['dark_area_land']
             water_threshold = fuzzy_option['dark_area_water']
-            low_backscatter = (intensity[int_id, :, :] < pol_threshold) 
+            low_backscatter = (intensity[int_id, :, :] < pol_threshold)
             # Low backscattering candidates
             low_backscatter_cand &= low_backscatter
             dark_water_cand &= intensity[int_id, :, :] < water_threshold

--- a/src/dswx_sar/fuzzy_value_computation.py
+++ b/src/dswx_sar/fuzzy_value_computation.py
@@ -9,7 +9,9 @@ import numpy as np
 from dswx_sar import (dswx_sar_util,
                       generate_log,
                       masking_with_ancillary)
-from dswx_sar.dswx_runconfig import _get_parser, RunConfig
+from dswx_sar.dswx_runconfig import (DSWX_S1_POL_DICT,
+                                     _get_parser,
+                                     RunConfig)
 
 logger = logging.getLogger('dswx_s1')
 
@@ -638,8 +640,20 @@ def main():
     if flag_first_file_is_text:
         cfg = RunConfig.load_from_yaml(args.input_yaml[0], 'dswx_s1', args)
 
-    run(cfg)
-
+    processing_cfg = cfg.groups.processing
+    pol_mode = processing_cfg.polarization_mode
+    pol_list = processing_cfg.polarizations
+    if pol_mode == 'MIX_DUAL_POL':
+        proc_pol_set = [DSWX_S1_POL_DICT['DV_POL'],
+                        DSWX_S1_POL_DICT['DH_POL']]
+    elif pol_mode == 'MIX_SINGLE_POL':
+        proc_pol_set = [DSWX_S1_POL_DICT['SV_POL'],
+                        DSWX_S1_POL_DICT['SH_POL']]
+    else:
+        proc_pol_set = [pol_list]
+    for pol_set in proc_pol_set:
+        processing_cfg.polarizations = pol_set
+        run(cfg)
 
 if __name__ == '__main__':
     main()

--- a/src/dswx_sar/initial_threshold.py
+++ b/src/dswx_sar/initial_threshold.py
@@ -1857,10 +1857,10 @@ def run(cfg):
                     mode_tau_set,
                     block_row,
                     block_col)
-                testtest = threshold_tau_set[:, :, 0]
-                testtest[testtest == -50] = np.nan
-                testtest = threshold_tau_set[:, :, 1]
-                testtest[testtest == -50] = np.nan
+                # testtest = threshold_tau_set[:, :, 0]
+                # testtest[testtest == -50] = np.nan
+                # testtest = threshold_tau_set[:, :, 1]
+                # testtest[testtest == -50] = np.nan
 
             else:
                 threshold_tau_set = [[], [], []]

--- a/src/dswx_sar/initial_threshold.py
+++ b/src/dswx_sar/initial_threshold.py
@@ -1857,10 +1857,6 @@ def run(cfg):
                     mode_tau_set,
                     block_row,
                     block_col)
-                # testtest = threshold_tau_set[:, :, 0]
-                # testtest[testtest == -50] = np.nan
-                # testtest = threshold_tau_set[:, :, 1]
-                # testtest[testtest == -50] = np.nan
 
             else:
                 threshold_tau_set = [[], [], []]

--- a/src/dswx_sar/masking_with_ancillary.py
+++ b/src/dswx_sar/masking_with_ancillary.py
@@ -17,7 +17,9 @@ from dswx_sar import (dswx_sar_util,
                       generate_log,
                       refine_with_bimodality,
                       region_growing)
-from dswx_sar.dswx_runconfig import _get_parser, RunConfig
+from dswx_sar.dswx_runconfig import (DSWX_S1_POL_DICT,
+                                     _get_parser,
+                                     RunConfig)
 
 
 logger = logging.getLogger('dswx_s1')
@@ -1067,8 +1069,20 @@ def main():
     if flag_first_file_is_text:
         cfg = RunConfig.load_from_yaml(args.input_yaml[0], 'dswx_s1', args)
 
-    run(cfg)
-
+    processing_cfg = cfg.groups.processing
+    pol_mode = processing_cfg.polarization_mode
+    pol_list = processing_cfg.polarizations
+    if pol_mode == 'MIX_DUAL_POL':
+        proc_pol_set = [DSWX_S1_POL_DICT['DV_POL'],
+                        DSWX_S1_POL_DICT['DH_POL']]
+    elif pol_mode == 'MIX_SINGLE_POL':
+        proc_pol_set = [DSWX_S1_POL_DICT['SV_POL'],
+                        DSWX_S1_POL_DICT['SH_POL']]
+    else:
+        proc_pol_set = [pol_list]
+    for pol_set in proc_pol_set:
+        processing_cfg.polarizations = pol_set
+        run(cfg)
 
 if __name__ == '__main__':
     main()

--- a/src/dswx_sar/mosaic_rtc_burst.py
+++ b/src/dswx_sar/mosaic_rtc_burst.py
@@ -9,6 +9,7 @@ import tempfile
 import time
 
 from collections import Counter
+from dataclasses import dataclass
 import h5py
 import numpy as np
 from osgeo import osr, gdal
@@ -19,6 +20,110 @@ from dswx_sar import (dswx_sar_util,
                       generate_log)
 
 logger = logging.getLogger('dswx_s1')
+
+
+@dataclass
+class DSWX_geogrid:
+    """
+    A dataclass representing the geographical grid configuration
+    for an RTC (Radar Terrain Correction) run.
+
+    Attributes:
+    -----------
+    start_x : float
+        The starting x-coordinate of the grid.
+    start_y : float
+        The starting y-coordinate of the grid.
+    end_x : float
+        The ending x-coordinate of the grid.
+    end_y : float
+        The ending y-coordinate of the grid.
+    spacing_x : float
+        The spacing between points in the x-direction.
+    spacing_y : float
+        The spacing between points in the y-direction.
+    length : int
+        The number of points in the y-direction.
+    width : int
+        The number of points in the x-direction.
+    epsg : int
+        The EPSG code representing the coordinate reference system of the grid.
+    """
+    start_x : float = np.nan
+    start_y : float = np.nan
+    end_x : float = np.nan
+    end_y : float = np.nan
+    spacing_x : float = np.nan
+    spacing_y : float = np.nan
+    length : int = np.nan
+    width : int = np.nan
+    epsg : int = np.nan
+
+    def get_geogrid_from_geotiff(self,
+                                 geotiff_path):
+        """
+        Extract geographical grid parameters from a GeoTIFF file
+        and update the dataclass attributes.
+
+        Parameters:
+        -----------
+        geotiff_path : str
+            The file path to the GeoTIFF file from which the grid
+            parameters are to be extracted.
+        """
+        tif_gdal = gdal.Open(geotiff_path)
+        geotransform = tif_gdal.GetGeoTransform()
+        self.start_x = geotransform[0]
+        self.spacing_x = geotransform[1]
+
+        self.start_y = geotransform[3]
+        self.spacing_y = geotransform[5]
+
+        self.length = tif_gdal.RasterYSize
+        self.width = tif_gdal.RasterXSize
+
+        self.end_x = self.start_x + self.width * self.spacing_x
+        self.end_y = self.start_y + self.length * self.spacing_y
+
+        projection = tif_gdal.GetProjection()
+        proj = osr.SpatialReference(wkt=projection)
+        output_epsg = proj.GetAttrValue('AUTHORITY',1)
+        self.epsg = int(output_epsg)
+        tif_gdal = None
+        del tif_gdal
+
+    def update_geogrid(self,
+                       geotiff_path):
+        """
+        Update the existing geographical grid parameters based on a new
+        GeoTIFF file. This function extends the grid to encompass both
+        the existing and new grid areas.
+
+        Parameters:
+        -----------
+        geotiff_path : str
+            The file path to the new GeoTIFF file from which the grid
+            parameters are to be updated.
+        """
+        new_geogrid = DSWX_geogrid()
+        new_geogrid.get_geogrid_from_geotiff(geotiff_path)
+
+        if (new_geogrid.epsg == self.epsg) or np.isnan(self.epsg):
+            self.start_x = np.nanmin([self.start_x, new_geogrid.start_x])
+            self.end_x = np.nanmax([self.end_x, new_geogrid.end_x])
+
+            if self.spacing_y > 0:
+                self.end_y = np.nanmax([self.end_y, new_geogrid.end_y])
+                self.start_y = np.nanmin([self.start_y, new_geogrid.start_y])
+            else:
+                self.start_y = np.nanmax([self.start_y, new_geogrid.start_y])
+                self.end_y = np.nanmin([self.end_y, new_geogrid.end_y])
+
+            self.spacing_x = new_geogrid.spacing_x
+            self.spacing_y = new_geogrid.spacing_y
+            self.width = int((self.end_x - self.start_x) / self.spacing_x)
+            self.length = int((self.end_y - self.start_y) / self.spacing_y)
+            self.epsg = new_geogrid.epsg
 
 
 def majority_element(num_list):
@@ -758,14 +863,13 @@ def run(cfg):
         freqA_path = '/data/'
 
         output_file_list = []
-        metadata_list = []
         nlooks_list = []
         mask_list = []
         epsg_list = []
 
         for ind, input_dir in enumerate(input_list):
 
-            first_rtc_path_iter = glob.iglob(f'{input_dir}/*_{first_pol}.tif')
+            first_rtc_path_iter = glob.iglob(f'{input_dir}/*.tif')
             first_rtc_path = next(first_rtc_path_iter)
             if first_rtc_path:
                 rtc_meta = dswx_sar_util.get_meta_from_tif(first_rtc_path)
@@ -775,6 +879,8 @@ def run(cfg):
                 raise FileExistsError(err_msg)
 
         epsg_output = majority_element(epsg_list)
+        geogrid_in = DSWX_geogrid()
+
         logger.info('All RTC bursts and associated masks will be mosaicked ' \
                     f'using the ESPG projection designated by {epsg_output}.')
         # for each directory, find metadata, and RTC files.
@@ -795,8 +901,11 @@ def run(cfg):
                         epsg_output=epsg_output,
                         output_nodata=255)
                     mask_list.append(temp_mask_path)
+                    geogrid_in.update_geogrid(temp_mask_path)
+
                 else:
                     mask_list.append(layover_path[0])
+                    geogrid_in.update_geogrid(layover_path[0])
 
             else:
                 # If mask GeoTiff is not available,
@@ -833,17 +942,22 @@ def run(cfg):
                 rtc_burst_imagery_list = []
 
                 for input_ind, input_dir in enumerate(input_list):
+                    try:
+                        rtc_path_input = glob.glob(f'{input_dir}/*_{pol}.tif')[0]
 
-                    rtc_path_input = glob.glob(f'{input_dir}/*_{pol}.tif')[0]
-                    if epsg_output != epsg_list[input_ind]:
-                        rtc_path_temp = f'{scratch_path}/temp_{pol}_{input_ind}.tif'
-                        dswx_sar_util.change_epsg_tif(rtc_path_input,
-                                                      rtc_path_temp,
-                                                      epsg_output)
-                        rtc_burst_imagery_list.append(rtc_path_temp)
-                    else:
-                        rtc_burst_imagery_list.append(rtc_path_input)
+                        if epsg_output != epsg_list[input_ind]:
+                            rtc_path_temp = f'{scratch_path}/temp_{pol}_{input_ind}.tif'
+                            dswx_sar_util.change_epsg_tif(rtc_path_input,
+                                                        rtc_path_temp,
+                                                        epsg_output)
+                            rtc_burst_imagery_list.append(rtc_path_temp)
+                            geogrid_in.update_geogrid(rtc_path_temp)
+                        else:
+                            rtc_burst_imagery_list.append(rtc_path_input)
+                            geogrid_in.update_geogrid(rtc_path_input)
 
+                    except:
+                        print(f'polarzation {pol} is not found in {input_dir}')
                 nlooks_list = []
 
                 if len(rtc_burst_imagery_list) > 0:
@@ -856,7 +970,7 @@ def run(cfg):
                     mosaic_single_output_file(
                         rtc_burst_imagery_list, nlooks_list, geo_pol_filename,
                         mosaic_mode, scratch_dir=scratch_path,
-                        geogrid_in=None, temp_files_list=None)
+                        geogrid_in=geogrid_in, temp_files_list=None)
 
         if mask_list:
             geo_mask_filename = \
@@ -867,7 +981,7 @@ def run(cfg):
             mosaic_single_output_file(
                 mask_list, nlooks_list, geo_mask_filename,
                 mosaic_mode, scratch_dir=scratch_path,
-                geogrid_in=None, temp_files_list=None,
+                geogrid_in=geogrid_in, temp_files_list=None,
                 no_data_value=255)
 
         # save files as COG format.

--- a/src/dswx_sar/mosaic_rtc_burst.py
+++ b/src/dswx_sar/mosaic_rtc_burst.py
@@ -9,121 +9,18 @@ import tempfile
 import time
 
 from collections import Counter
-from dataclasses import dataclass
 import h5py
 import numpy as np
 from osgeo import osr, gdal
 from scipy import ndimage
 
 from dswx_sar.dswx_runconfig import _get_parser, RunConfig
-from dswx_sar import (dswx_sar_util,
+from dswx_sar import (dswx_geogrid,
+                      dswx_sar_util,
                       generate_log)
 
 logger = logging.getLogger('dswx_s1')
 
-
-@dataclass
-class DSWX_geogrid:
-    """
-    A dataclass representing the geographical grid configuration
-    for an RTC (Radar Terrain Correction) run.
-
-    Attributes:
-    -----------
-    start_x : float
-        The starting x-coordinate of the grid.
-    start_y : float
-        The starting y-coordinate of the grid.
-    end_x : float
-        The ending x-coordinate of the grid.
-    end_y : float
-        The ending y-coordinate of the grid.
-    spacing_x : float
-        The spacing between points in the x-direction.
-    spacing_y : float
-        The spacing between points in the y-direction.
-    length : int
-        The number of points in the y-direction.
-    width : int
-        The number of points in the x-direction.
-    epsg : int
-        The EPSG code representing the coordinate reference system of the grid.
-    """
-    start_x : float = np.nan
-    start_y : float = np.nan
-    end_x : float = np.nan
-    end_y : float = np.nan
-    spacing_x : float = np.nan
-    spacing_y : float = np.nan
-    length : int = np.nan
-    width : int = np.nan
-    epsg : int = np.nan
-
-    def get_geogrid_from_geotiff(self,
-                                 geotiff_path):
-        """
-        Extract geographical grid parameters from a GeoTIFF file
-        and update the dataclass attributes.
-
-        Parameters:
-        -----------
-        geotiff_path : str
-            The file path to the GeoTIFF file from which the grid
-            parameters are to be extracted.
-        """
-        tif_gdal = gdal.Open(geotiff_path)
-        geotransform = tif_gdal.GetGeoTransform()
-        self.start_x = geotransform[0]
-        self.spacing_x = geotransform[1]
-
-        self.start_y = geotransform[3]
-        self.spacing_y = geotransform[5]
-
-        self.length = tif_gdal.RasterYSize
-        self.width = tif_gdal.RasterXSize
-
-        self.end_x = self.start_x + self.width * self.spacing_x
-        self.end_y = self.start_y + self.length * self.spacing_y
-
-        projection = tif_gdal.GetProjection()
-        proj = osr.SpatialReference(wkt=projection)
-        output_epsg = proj.GetAttrValue('AUTHORITY',1)
-        self.epsg = int(output_epsg)
-        tif_gdal = None
-        del tif_gdal
-
-    def update_geogrid(self,
-                       geotiff_path):
-        """
-        Update the existing geographical grid parameters based on a new
-        GeoTIFF file. This function extends the grid to encompass both
-        the existing and new grid areas.
-
-        Parameters:
-        -----------
-        geotiff_path : str
-            The file path to the new GeoTIFF file from which the grid
-            parameters are to be updated.
-        """
-        new_geogrid = DSWX_geogrid()
-        new_geogrid.get_geogrid_from_geotiff(geotiff_path)
-
-        if (new_geogrid.epsg == self.epsg) or np.isnan(self.epsg):
-            self.start_x = np.nanmin([self.start_x, new_geogrid.start_x])
-            self.end_x = np.nanmax([self.end_x, new_geogrid.end_x])
-
-            if self.spacing_y > 0:
-                self.end_y = np.nanmax([self.end_y, new_geogrid.end_y])
-                self.start_y = np.nanmin([self.start_y, new_geogrid.start_y])
-            else:
-                self.start_y = np.nanmax([self.start_y, new_geogrid.start_y])
-                self.end_y = np.nanmin([self.end_y, new_geogrid.end_y])
-
-            self.spacing_x = new_geogrid.spacing_x
-            self.spacing_y = new_geogrid.spacing_y
-            self.width = int((self.end_x - self.start_x) / self.spacing_x)
-            self.length = int((self.end_y - self.start_y) / self.spacing_y)
-            self.epsg = new_geogrid.epsg
 
 
 def majority_element(num_list):
@@ -879,7 +776,7 @@ def run(cfg):
                 raise FileExistsError(err_msg)
 
         epsg_output = majority_element(epsg_list)
-        geogrid_in = DSWX_geogrid()
+        geogrid_in = dswx_geogrid.DSWXGeogrid()
 
         logger.info('All RTC bursts and associated masks will be mosaicked ' \
                     f'using the ESPG projection designated by {epsg_output}.')
@@ -901,6 +798,8 @@ def run(cfg):
                         epsg_output=epsg_output,
                         output_nodata=255)
                     mask_list.append(temp_mask_path)
+
+                    # update geogrid using new GeoTiff file.
                     geogrid_in.update_geogrid(temp_mask_path)
 
                 else:
@@ -942,21 +841,23 @@ def run(cfg):
                 rtc_burst_imagery_list = []
 
                 for input_ind, input_dir in enumerate(input_list):
-                    try:
-                        rtc_path_input = glob.glob(f'{input_dir}/*_{pol}.tif')[0]
+                    rtc_path_inputs = glob.glob(f'{input_dir}/*_{pol}.tif')
+                    if rtc_path_inputs:
+                        rtc_path_input = rtc_path_inputs[0]
 
                         if epsg_output != epsg_list[input_ind]:
                             rtc_path_temp = f'{scratch_path}/temp_{pol}_{input_ind}.tif'
                             dswx_sar_util.change_epsg_tif(rtc_path_input,
-                                                        rtc_path_temp,
-                                                        epsg_output)
+                                                          rtc_path_temp,
+                                                          epsg_output)
                             rtc_burst_imagery_list.append(rtc_path_temp)
+
+                            # update geogrid using new GeoTiff file.
                             geogrid_in.update_geogrid(rtc_path_temp)
                         else:
                             rtc_burst_imagery_list.append(rtc_path_input)
                             geogrid_in.update_geogrid(rtc_path_input)
-
-                    except:
+                    else:
                         print(f'polarzation {pol} is not found in {input_dir}')
                 nlooks_list = []
 

--- a/src/dswx_sar/pre_processing.py
+++ b/src/dswx_sar/pre_processing.py
@@ -75,9 +75,7 @@ class AncillaryRelocation:
             file name of output
         method : str
             interpolation method
-
         """
-
         self._interpolate_gdal(str(self.rtc_file_name),
                               ancillary_file_name,
                               os.path.join(self.scratch_dir,
@@ -90,7 +88,7 @@ class AncillaryRelocation:
                           method):
 
         """Interpolate the input image to have same projection and resolution
-        as the refernce file.
+        as the reference file.
 
         Parameters
         ----------
@@ -103,7 +101,6 @@ class AncillaryRelocation:
         method : str
             interpolation method
         """
-
         print(f"> gdalwarp {input_tif_str} -> {output_tif_str}")
 
         # get reference coordinate and projection
@@ -407,7 +404,7 @@ def run(cfg):
         scratch_dir=scratch_dir)
     del intensity_filt
 
-    no_data_geotiff_path = os.path.join(scratch_dir, 
+    no_data_geotiff_path = os.path.join(scratch_dir,
                                         f"no_data_area_{pol_all_str}.tif")
     dswx_sar_util.get_invalid_area(
         os.path.join(scratch_dir, filtered_images_str),

--- a/src/dswx_sar/pre_processing.py
+++ b/src/dswx_sar/pre_processing.py
@@ -9,7 +9,9 @@ from osgeo import gdal, osr
 from pathlib import Path
 
 from dswx_sar import dswx_sar_util, filter_SAR, generate_log
-from dswx_sar.dswx_runconfig import _get_parser, RunConfig
+from dswx_sar.dswx_runconfig import (DSWX_S1_POL_DICT,
+                                     _get_parser,
+                                     RunConfig)
 
 
 logger = logging.getLogger('dswx_s1')
@@ -436,8 +438,21 @@ def main():
 
     generate_log.configure_log_file(cfg.groups.log_file)
 
-    run(cfg)
+    processing_cfg = cfg.groups.processing
+    pol_mode = processing_cfg.polarization_mode
+    pol_list = processing_cfg.polarizations
+    if pol_mode == 'MIX_DUAL_POL':
+        proc_pol_set = [DSWX_S1_POL_DICT['DV_POL'],
+                        DSWX_S1_POL_DICT['DH_POL']]
+    elif pol_mode == 'MIX_SINGLE_POL':
+        proc_pol_set = [DSWX_S1_POL_DICT['SV_POL'],
+                        DSWX_S1_POL_DICT['SH_POL']]
+    else:
+        proc_pol_set = [pol_list]
 
+    for pol_set in proc_pol_set:
+        processing_cfg.polarizations = pol_set
+        run(cfg)
 
 if __name__ == '__main__':
     main()

--- a/src/dswx_sar/refine_with_bimodality.py
+++ b/src/dswx_sar/refine_with_bimodality.py
@@ -796,6 +796,9 @@ def remove_false_water_bimodality_parallel(water_mask,
     sizes = stats_water[1:, -1]
     bounding_boxes = stats_water[1:, :4]
 
+    bimodality_total = water_mask.copy()
+    del water_mask
+
     for pol_ind, pol in enumerate(pol_list):
         if pol in ['VV', 'VH', 'HH', 'HV']:
             # 1 dimensional array for bimodality values
@@ -1051,13 +1054,6 @@ def run(cfg):
     filt_im_str = os.path.join(outputdir, f"filtered_image_{pol_str}.tif")
     no_data_geotiff_path = os.path.join(outputdir, f"no_data_area_{pol_str}.tif")
     im_meta = dswx_sar_util.get_meta_from_tif(filt_im_str)
-
-    dswx_sar_util.get_invalid_area(
-        filt_im_str,
-        no_data_geotiff_path,
-        projection=im_meta['projection'],
-        geotransform=im_meta['geotransform'],
-        scratch_dir=outputdir)
 
     # read the result of landcover masindex_array_to_imageg
     water_map_tif_str =  os.path.join(outputdir,

--- a/src/dswx_sar/refine_with_bimodality.py
+++ b/src/dswx_sar/refine_with_bimodality.py
@@ -739,6 +739,8 @@ def remove_false_water_bimodality_parallel(water_mask,
     Remove falsely detected water bimodality from an image in parallel.
     This function identifies and processes areas of water and adjacent lands
     to verify and refine the accuracy of water detection in an image.
+    This function should be used only for ['VV', 'VH', 'HH', 'HV'].
+    In the case that the other polarization is given, then return input as it is. 
 
     Parameters:
     -----------
@@ -769,7 +771,7 @@ def remove_false_water_bimodality_parallel(water_mask,
     bimodality_total: numpy.ndarray
         An image indicating the bimodality values across the entire scene.
     """
-
+    print('pol_list', pol_list)
     rows, cols = meta_info['length'], meta_info['width']
 
     # computes the connected components labeled image of boolean image
@@ -796,11 +798,14 @@ def remove_false_water_bimodality_parallel(water_mask,
     sizes = stats_water[1:, -1]
     bounding_boxes = stats_water[1:, :4]
 
+    # If the polarization is not in the list ['VV', 'VH', 'HH', 'HV'],
+    # Return input as it is without further modification.
     bimodality_total = water_mask.copy()
     del water_mask
 
     for pol_ind, pol in enumerate(pol_list):
         if pol in ['VV', 'VH', 'HH', 'HV']:
+            logger.info(f'removing false water using bimodality for {pol}')
             # 1 dimensional array for bimodality values
             bimodality_array = np.zeros([nb_components_water])
 
@@ -1099,7 +1104,7 @@ def run(cfg):
     bimodal_binary = \
         remove_false_water_bimodality_parallel(
             water_mask_image==1,
-            pol_list=[co_pol],
+            pol_list=co_pol,
             thresholds=[ashman_threshold,
                         bhc_threshold,
                         surface_ratio_threshold,

--- a/src/dswx_sar/save_mgrs_tiles.py
+++ b/src/dswx_sar/save_mgrs_tiles.py
@@ -13,17 +13,67 @@ from osgeo import gdal, osr
 from pyproj import CRS
 import rasterio
 from rasterio.warp import transform_bounds
+from rasterio.merge import merge
 from shapely.geometry import Polygon
 
 from dswx_sar import (dswx_sar_util,
                       generate_log)
 from dswx_sar.dswx_sar_util import band_assign_value_dict
-from dswx_sar.dswx_runconfig import RunConfig, _get_parser
+from dswx_sar.dswx_runconfig import RunConfig, _get_parser, dswx_s1_pol_dict
 from dswx_sar.metadata import (create_dswx_sar_metadata,
                                collect_burst_id,
                                _populate_statics_metadata_datasets)
 
 logger = logging.getLogger('dswx_s1')
+
+
+def merge_pol_layers(list_layers,
+                 output_file,
+                 nodata_value=None,
+                 scratch_dir='.'):
+    """
+    Merge multiple GeoTIFF files into a single file using rasterio.
+    This function is used to merge the GeoTIFF with different polarizaitons. 
+
+    Parameters
+    ----------
+    list_layers : list
+        List of GeoTIFF file paths to be merged.
+    output_file : str
+        Path for the output merged GeoTIFF file.
+    nodata_value : float
+        The no-data value to be considered in the merge.
+    """
+    print(list_layers)
+    # Open all the source files
+    src_files_to_mosaic = []
+    for file in list_layers:
+        src = rasterio.open(file)
+        src_files_to_mosaic.append(src)
+
+    # Merge function
+    if nodata_value is not None:
+        mosaic, out_trans = merge(src_files_to_mosaic, nodata=nodata_value)
+    else:
+        mosaic, out_trans = merge(src_files_to_mosaic)
+
+    # Copy metadata
+    out_meta = src.meta.copy()
+
+    # Update the metadata
+    out_meta.update({"driver": "GTiff",
+                     "height": mosaic.shape[1],
+                     "width": mosaic.shape[2],
+                     "transform": out_trans,})
+
+    # Write the mosaic raster to disk
+    with rasterio.open(output_file, "w", **out_meta) as dest:
+        dest.write(mosaic)
+
+    # Close the source files
+    for src in src_files_to_mosaic:
+        src.close()
+    dswx_sar_util._save_as_cog(output_file, scratch_dir)
 
 
 def get_bounding_box_from_mgrs_tile_db(
@@ -155,37 +205,39 @@ def find_intersecting_burst_with_bbox(ref_bbox,
 
     overlapped_rtc_dir_list = []
     for input_dir in input_rtc_dirs:
-        copol_rtc_path_iter = glob.iglob(f'{input_dir}/*_VV*.tif')
-        copol_rtc_path = next(copol_rtc_path_iter)
+        copol_file_list = []
+        for copol in dswx_s1_pol_dict['CO_POL']:
+            copol_rtc_path = glob.glob(f'{input_dir}/*_{copol}*.tif')
+            copol_file_list.extend(copol_rtc_path)
 
-        if not copol_rtc_path:
-            copol_rtc_path_iter = glob.iglob(f'{input_dir}/*_HH*.tif')
-            copol_rtc_path = next(copol_rtc_path_iter)
+        if copol_file_list:
+            with rasterio.open(copol_file_list[0]) as src:
+                epsg_code = int(src.crs.data['init'].split(':')[1])
 
-        with rasterio.open(copol_rtc_path) as src:
-            epsg_code = int(src.crs.data['init'].split(':')[1])
+                # Get bounds of the raster data
+                left, bottom, right, top = src.bounds
 
-            # Get bounds of the raster data
-            left, bottom, right, top = src.bounds
+                # Reproject to EPSG 4326 if the current EPSG is not 4326
+                if epsg_code != ref_epsg:
+                    left, bottom, right, top = \
+                        transform_bounds(src.crs,
+                                        {'init': f'EPSG:{ref_epsg}'},
+                                        left,
+                                        bottom,
+                                        right,
+                                        top)
+                rtc_polygon = Polygon([(left, bottom),
+                                    (left, top),
+                                    (right, top),
+                                    (right, bottom)])
 
-            # Reproject to EPSG 4326 if the current EPSG is not 4326
-            if epsg_code != ref_epsg:
-                left, bottom, right, top = \
-                    transform_bounds(src.crs,
-                                     {'init': f'EPSG:{ref_epsg}'},
-                                     left,
-                                     bottom,
-                                     right,
-                                     top)
-            rtc_polygon = Polygon([(left, bottom),
-                                   (left, top),
-                                   (right, top),
-                                   (right, bottom)])
-
-        # Check if bursts intersect the reference polygon
-        if ref_polygon.intersects(rtc_polygon) or \
-           ref_polygon.overlaps(rtc_polygon):
-            overlapped_rtc_dir_list.append(input_dir)
+            # Check if bursts intersect the reference polygon
+            if ref_polygon.intersects(rtc_polygon) or \
+            ref_polygon.overlaps(rtc_polygon):
+                overlapped_rtc_dir_list.append(input_dir)
+        else:
+            print('fail to find the overlapped rtc')
+            overlapped_rtc_dir_list = None
 
     return overlapped_rtc_dir_list
 
@@ -461,6 +513,7 @@ def run(cfg):
     # Processing parameters
     processing_cfg = cfg.groups.processing
     pol_str = '_'.join(processing_cfg.polarizations)
+    pol_mode = processing_cfg.polarization_mode
     co_pol = processing_cfg.copol
     input_list = cfg.groups.input_file_group.input_file_path
     dswx_workflow = processing_cfg.dswx_workflow
@@ -516,27 +569,49 @@ def run(cfg):
         platform_str = 'unknown'
         resolution_str = 'unknown'
 
+    # Set merge_layer_flag and merge_pol_list based on pol_mode
+    merge_layer_flag = pol_mode in ['MIX_DUAL_POL', 'MIX_SINGLE_POL']
+    pol_type = 'DV_POL' if pol_mode == 'MIX_DUAL_POL' else 'SV_POL'
+    merge_pol_list = ['_'.join(dswx_s1_pol_dict[pol_type]),
+                      '_'.join(dswx_s1_pol_dict[pol_type.replace('V', 'H')])]
+
     # Depending on the workflow, the final product are different.
-    if dswx_workflow == 'opera_dswx_s1':
-        final_water_path = \
-            os.path.join(outputdir,
-                         f'bimodality_output_binary_{pol_str}.tif')
-    else:
-        # twele's workflow
-        final_water_path = \
-            os.path.join(outputdir,
-                         f'region_growing_output_binary_{pol_str}.tif')
+    prefix_dict = {
+    'final_water': 'bimodality_output_binary'
+        if dswx_workflow == 'opera_dswx_s1' else 'region_growing_output_binary',
+    'landcover_mask': 'refine_landcover_binary',
+    'no_data_area': 'no_data_area',
+    'inundated_veg': 'temp_inundated_vegetation',
+    'region_growing': 'region_growing_output_binary',
+    'fuzzy_value': 'fuzzy_image'
+    }
+
+    paths = {}
+    for key, prefix in prefix_dict.items():
+        file_path = f'{prefix}_{pol_str}.tif'
+        paths[key] = os.path.join(outputdir, file_path)
+        if merge_layer_flag:
+            list_layers = [os.path.join(outputdir, f'{prefix}_{pol_cand_str}.tif')
+                           for pol_cand_str in merge_pol_list]
+            if key == 'no_data_area':
+                extra_args = {'nodata_value': 1}
+            elif key == 'fuzzy_value':
+                extra_args = {'nodata_value': -1}
+            else:
+                extra_args = {'nodata_value': 0}
+            merge_pol_layers(list_layers,
+                         os.path.join(outputdir, file_path),
+                         **extra_args)
 
     # metadata for final product
     # e.g. geotransform, projection, length, width, utmzon, epsg
-    water_meta = dswx_sar_util.get_meta_from_tif(final_water_path)
+    water_meta = dswx_sar_util.get_meta_from_tif(paths['final_water'])
 
     # repackage the water map
     # 1) water map
-    water_map = dswx_sar_util.read_geotiff(final_water_path)
-    no_data_geotiff_path = os.path.join(outputdir, f"no_data_area_{pol_str}.tif")
-    no_data_raster = dswx_sar_util.read_geotiff(no_data_geotiff_path)
-    no_data_raster = no_data_raster | \
+    water_map = dswx_sar_util.read_geotiff(paths['final_water'])
+    no_data_raster = dswx_sar_util.read_geotiff(paths['no_data_area'])
+    no_data_raster = (no_data_raster > 0) | \
         (water_map == band_assign_value_dict['no_data'])
 
     # 2) layover/shadow
@@ -566,7 +641,7 @@ def run(cfg):
     # 4) inundated_vegetation
     if processing_cfg.inundated_vegetation.enabled:
         inundated_vegetation = dswx_sar_util.read_geotiff(
-            os.path.join(outputdir, "temp_inundated_vegetation.tif"))
+            paths['inundated_veg'])
         inundated_vegetation_mask = (inundated_vegetation == 2) & \
                                     (water_map == 1)
         inundated_vegetation[inundated_vegetation_mask] = 1
@@ -579,13 +654,9 @@ def run(cfg):
         logger.info('BWTR and WTR Files are created from pre-computed files.')
 
         region_grow_map = \
-            dswx_sar_util.read_geotiff(
-                os.path.join(outputdir,
-                             f'region_growing_output_binary_{pol_str}.tif'))
+            dswx_sar_util.read_geotiff(paths['region_growing'])
         landcover_map =\
-            dswx_sar_util.read_geotiff(
-                os.path.join(outputdir,
-                             f'refine_landcover_binary_{pol_str}.tif'))
+            dswx_sar_util.read_geotiff(paths['landcover_mask'])
         landcover_mask = (region_grow_map == 1) & (landcover_map != 1)
         dark_land_mask = (landcover_map == 1) & (water_map == 0)
         bright_water_mask = (landcover_map == 0) & (water_map == 1)
@@ -621,8 +692,7 @@ def run(cfg):
             hand_mask=hand_mask,
             no_data=no_data_raster)
 
-        fuzzy_value = dswx_sar_util.read_geotiff(
-            os.path.join(outputdir, f'fuzzy_image_{pol_str}.tif'))
+        fuzzy_value = dswx_sar_util.read_geotiff(paths['fuzzy_value'])
         conf_value = np.round(fuzzy_value * 100)
 
         dswx_sar_util.save_dswx_product(
@@ -658,7 +728,7 @@ def run(cfg):
     if database_bool:
         mgrs_tile_list, most_overlapped = get_intersecting_mgrs_tiles_list_from_db(
             mgrs_collection_file=mgrs_collection_db_path,
-            image_tif=final_water_path)
+            image_tif=paths['final_water'])
         maximum_burst = most_overlapped['number_of_bursts']
         expected_burst_list = most_overlapped['bursts']
 
@@ -676,7 +746,7 @@ def run(cfg):
 
     else:
         mgrs_tile_list = get_intersecting_mgrs_tiles_list(
-            image_tif=final_water_path)
+            image_tif=paths['final_water'])
 
     unique_mgrs_tile_list = list(set(mgrs_tile_list))
     logger.info(f'MGRS tiles: {unique_mgrs_tile_list}')

--- a/src/dswx_sar/schemas/algorithm_parameter_s1.yaml
+++ b/src/dswx_sar/schemas/algorithm_parameter_s1.yaml
@@ -8,6 +8,8 @@ runconfig:
 
         # Polarizations to be used for DSWx-SAR
         # [polarizations] for list of specific frequency(s) e.g. [VV, VH] or [VV]
+        # 'dual-pol', 'co-pol', 'cross-pol' will search the polarizations Input GeoTiff files have. 
+        # For example, 'co-pol' uses ['HH'], ['VV'], or ['HH', 'VV'] by looking at the input data. 
         polarizations: any(list(str(min=2, max=10), min=1, max=4), str(min=4, max=4), null(), required=False)
 
         # Specifiy the max_value for permanent water and no_data_value for invalid pixels


### PR DESCRIPTION
This PR adds the capability to use `['dual-pol'], ['single-pol'], ['cross-pol']` for the polarizations in runconfig. 
When these polarizations are provided, the algorithm will search for the corresponding polarizations within the input RTC files and utilize them for subsequent processing. This enhancement adds more flexibility in polarization selection for the algorithm.