### PR TITLE
fix bugs in ocean area

### DIFF
--- a/src/dswx_sar/refine_with_bimodality.py
+++ b/src/dswx_sar/refine_with_bimodality.py
@@ -572,7 +572,10 @@ def process_dark_land_component(args):
     metric_output_i = np.zeros(5)
     watermask = water_label == i + 1
 
-    mask = np.array((watermask==1) & (landcover != 0))
+    # water mask == 1 represents areas where water is located from
+    # previous step. landcover == 0  is the no-data area
+    # & (landcover != 0) may beed to be added.
+    mask = np.array((watermask==1))
 
     # ref_land consists of 0 and 1 values
     ref_land_masked = ref_land[mask]


### PR DESCRIPTION
The previous code had a bug in classifying ocean water (see attached figure). This PR fixes the bug in `refine_with_bimodality.py`.
![Screenshot 2023-12-19 at 11 36 55 AM](https://github.com/opera-adt/DSWX-SAR/assets/56169931/b890aca0-3d35-4293-80e4-5bbfb41e10ba)
