### PR TITLE
add sanity checker and replacement of no-data

### DIFF
--- a/src/dswx_sar/detect_inundated_vegetation.py
+++ b/src/dswx_sar/detect_inundated_vegetation.py
@@ -120,7 +120,9 @@ def run(cfg):
             block_param=block_param,
             geotransform=im_meta['geotransform'],
             projection=im_meta['projection'],
-            datatype='byte')
+            datatype='byte',
+            cog_flag=True,
+            scratch_dir=outputdir)
 
         if processing_cfg.debug_mode:
             dswx_sar_util.write_raster_block(
@@ -130,7 +132,9 @@ def run(cfg):
                 block_param=block_param,
                 geotransform=im_meta['geotransform'],
                 projection=im_meta['projection'],
-                datatype='float32')
+                datatype='float32',
+                cog_flag=True,
+                scratch_dir=outputdir)
 
     dswx_sar_util._save_as_cog(inundated_vege_path, outputdir)
 

--- a/src/dswx_sar/fuzzy_value_computation.py
+++ b/src/dswx_sar/fuzzy_value_computation.py
@@ -67,7 +67,7 @@ def create_slope_angle_geotiff(dem_path,
         data_shape=(im_meta['length'],
                     im_meta['width']),
         pad_shape=pad_shape)
-    print('scratch', scratch_dir)
+
     for block_param in block_params:
         dem = dswx_sar_util.get_raster_block(
             dem_path,

--- a/src/dswx_sar/fuzzy_value_computation.py
+++ b/src/dswx_sar/fuzzy_value_computation.py
@@ -55,24 +55,19 @@ def create_slope_angle_geotiff(dem_path,
         GeoTiff path for filename to read input dem
     slope_path: str
         full path for filename to save the slope angle
-    geotransform: gdal
-        gdaltransform information
-    projection: gdal
-        projection object
-    scratch_dir: str
-        temporary file path to process COG file.
     lines_per_block: int
         lines per block processing
     """
     pad_shape = (SOBEL_KERNEL_SIZE, 0)
     im_meta = dswx_sar_util.get_meta_from_tif(dem_path)
+    scratch_dir = os.path.dirname(slope_path)
 
     block_params = dswx_sar_util.block_param_generator(
         lines_per_block=lines_per_block,
         data_shape=(im_meta['length'],
                     im_meta['width']),
         pad_shape=pad_shape)
-
+    print('scratch', scratch_dir)
     for block_param in block_params:
         dem = dswx_sar_util.get_raster_block(
             dem_path,
@@ -85,7 +80,9 @@ def create_slope_angle_geotiff(dem_path,
             block_param=block_param,
             geotransform=im_meta['geotransform'],
             projection=im_meta['projection'],
-            datatype='float32')
+            datatype='float32',
+            cog_flag=True,
+            scratch_dir=scratch_dir)
 
 
 def smf(values, minv, maxv):
@@ -581,7 +578,9 @@ def run(cfg):
             block_param=block_param,
             geotransform=im_meta['geotransform'],
             projection=im_meta['projection'],
-            datatype='float32')
+            datatype='float32',
+            cog_flag=True,
+            scratch_dir=outputdir)
 
         if processing_cfg.debug_mode:
 
@@ -600,7 +599,9 @@ def run(cfg):
                     block_param=block_param,
                     geotransform=im_meta['geotransform'],
                     projection=im_meta['projection'],
-                    datatype='float32')
+                    datatype='float32',
+                    cog_flag=True,
+                    scratch_dir=outputdir)
 
             for polind, pol in enumerate(pol_list):
                 dswx_sar_util.write_raster_block(
@@ -612,7 +613,9 @@ def run(cfg):
                     block_param=block_param,
                     geotransform=im_meta['geotransform'],
                     projection=im_meta['projection'],
-                    datatype='float32')
+                    datatype='float32',
+                    cog_flag=True,
+                    scratch_dir=outputdir)
 
     if processing_cfg.debug_mode:
 

--- a/src/dswx_sar/initial_threshold.py
+++ b/src/dswx_sar/initial_threshold.py
@@ -1299,6 +1299,13 @@ def fill_threshold_with_gdal(threshold_array,
             # Close the dataset
             ds = None
 
+        dswx_sar_util._save_as_cog(
+            tif_file_str,
+            outputdir,
+            logger,
+            compression='DEFLATE',
+            nbits=16)
+
 
 def fill_threshold_with_distance(threshold_array,
                                  rows,

--- a/src/dswx_sar/masking_with_ancillary.py
+++ b/src/dswx_sar/masking_with_ancillary.py
@@ -607,7 +607,6 @@ def extend_land_cover(landcover_path,
         excluded_rg_path,
         geotransform=metainfo['geotransform'],
         projection=metainfo['projection'],
-        description='Water classification (WTR)',
         scratch_dir=scratch_dir
         )
 
@@ -618,7 +617,6 @@ def extend_land_cover(landcover_path,
         darkland_tif_str,
         geotransform=metainfo['geotransform'],
         projection=metainfo['projection'],
-        description='Water classification (WTR)',
         scratch_dir=scratch_dir
         )
 

--- a/src/dswx_sar/pre_processing.py
+++ b/src/dswx_sar/pre_processing.py
@@ -295,7 +295,9 @@ def replace_reference_water_nodata_from_ancillary(
             block_param=block_param,
             geotransform=im_meta['geotransform'],
             projection=im_meta['projection'],
-            datatype='float32')
+            datatype='float32',
+            cog_flag=True,
+            scratch_dir=scratch_dir)
 
 
 def run(cfg):

--- a/src/dswx_sar/pre_processing.py
+++ b/src/dswx_sar/pre_processing.py
@@ -61,7 +61,7 @@ def validate_gtiff(geotiff_path, value_list):
     """
     image = dswx_sar_util.read_geotiff(geotiff_path)    
     mean_value = np.nanmean(image)
-    print(f'checking {geotiff_path}')
+
     validation_result = 'okay'
 
     for invalid_value in value_list:
@@ -153,7 +153,7 @@ class AncillaryRelocation:
         method : str
             interpolation method
         """
-        print(f"> gdalwarp {input_tif_str} -> {output_tif_str}")
+        print(f"   >> gdalwarp {input_tif_str} -> {output_tif_str}")
 
         # get reference coordinate and projection
         reftif = gdal.Open(ref_file, gdal.GA_ReadOnly)
@@ -175,7 +175,7 @@ class AncillaryRelocation:
                           np.min(lon0) - xspacing / 2,
                           np.max(lon0) + xspacing / 2]
 
-            print('Note: latitude shape is not same as image shape')
+            print('    Note: latitude shape is not same as image shape')
 
         else:
             N, S, W, E = [np.max(lat0),
@@ -183,7 +183,7 @@ class AncillaryRelocation:
                           np.min(lon0),
                           np.max(lon0)]
 
-        print('bounding box', N, S , W, E)
+        print('   bounding box', N, S , W, E)
 
         # Crop (gdalwarp)image based on geo infomation of reference image
         if yspacing < 0:
@@ -399,7 +399,8 @@ def run(cfg):
             os.path.join(scratch_dir, anc_filename))
 
         # Check if input ancillary data is valid. 
-        if not os.path.isfile(dem_file):
+        if not os.path.isfile(input_anc_path) and \
+            not check_gdal_raster_s3(input_anc_path, raise_error=False):
             err_msg = f'Input {anc_type} file not found'
             raise FileNotFoundError(err_msg)
 
@@ -407,7 +408,6 @@ def run(cfg):
             no_data = ref_water_no_data
         elif anc_type in ['landcover']:
             no_data = landcover_label['No_data']
-
         else:
             no_data = np.nan
 
@@ -463,14 +463,14 @@ def run(cfg):
     for block_ind, block_param in enumerate(block_params):
         output_image_set = []
         for polind, pol in enumerate(pol_list):
-            logger.info(f'block processing {block_ind} - {pol}')
+            logger.info(f'  block processing {block_ind} - {pol}')
 
             if pol in ['ratio', 'span']:
 
                 # If ratio/span is in the list,
                 # then compute the ratio from VVVV and VHVH
                 temp_pol_list = co_pol + cross_pol
-                logger.info(f'>> computing {pol} {temp_pol_list}')
+                logger.info(f'  >> computing {pol} {temp_pol_list}')
 
                 temp_raster_set = []
                 for temp_pol in temp_pol_list:
@@ -488,7 +488,7 @@ def run(cfg):
                     ratio = pol_ratio(np.squeeze(temp_raster_set[0, :, :]),
                                       np.squeeze(temp_raster_set[1, :, :]))
                     output_image_set.append(ratio)
-                    logger.info(f'computing ratio {co_pol}/{cross_pol}')
+                    logger.info(f'  computing ratio {co_pol}/{cross_pol}')
 
                 if pol in ['span']:
                     span = np.squeeze(temp_raster_set[0, :, :] +

--- a/src/dswx_sar/pre_processing.py
+++ b/src/dswx_sar/pre_processing.py
@@ -40,7 +40,7 @@ def validate_gtiff(geotiff_path, value_list):
     2. If the mean value equals any value in the provided 'value_list',
        it suggests that all pixels in the file might have the same value.
 
-    Parameters:
+    Parameters
     -----------
     geotiff_path : str
         The file path to the GeoTIFF file to be checked.
@@ -48,13 +48,13 @@ def validate_gtiff(geotiff_path, value_list):
         A list of values against which the mean pixel value of the GeoTIFF
         file is compared.
 
-    Return:
+    Returns
     -------
-    validation_result: bool
+    validation_result: str
         If any of the checks fail, return bool indicating potential issues
         with the GeoTIFF file.
         - Return 'nan_value' if some pixels in the file have NaN values.
-        - Return 'no_data_only' if the mean pixel value matches any value
+        - Return 'invalid_only' if the mean pixel value matches any value
           in 'value_list', suggesting uniform pixel values across the file.
     """
     image = dswx_sar_util.read_geotiff(geotiff_path)    
@@ -77,6 +77,7 @@ def validate_gtiff(geotiff_path, value_list):
                        'the specified invalid value list.')
 
     return validation_result
+
 
 class AncillaryRelocation:
     '''
@@ -423,7 +424,7 @@ def run(cfg):
             os.path.join(scratch_dir, anc_filename),
             [no_data, np.inf])
 
-        if validation_result not in 'okay':
+        if validation_result not in ['okay']:
             if (anc_type in ['dem', 'hand']) and \
                 (validation_result in ['nan_value', 'invalid_only']):
                 err_msg = f'Unable to get valid {anc_type}'

--- a/src/dswx_sar/pre_processing.py
+++ b/src/dswx_sar/pre_processing.py
@@ -4,6 +4,7 @@ import mimetypes
 import numpy as np
 import os
 import pathlib
+import shutil
 import time
 
 from osgeo import gdal, osr
@@ -13,7 +14,7 @@ from dswx_sar import dswx_sar_util, filter_SAR, generate_log
 from dswx_sar.dswx_runconfig import (DSWX_S1_POL_DICT,
                                      _get_parser,
                                      RunConfig)
-
+from dswx_sar.masking_with_ancillary import get_label_landcover_esa_10
 
 logger = logging.getLogger('dswx_s1')
 
@@ -47,22 +48,35 @@ def validate_gtiff(geotiff_path, value_list):
         A list of values against which the mean pixel value of the GeoTIFF
         file is compared.
 
-    Raises:
+    Return:
     -------
-    ValueError:
-        If any of the checks fail, indicating potential issues
+    validation_result: bool
+        If any of the checks fail, return bool indicating potential issues
         with the GeoTIFF file.
-        - Raises an error if some pixels in the file have NaN values.
-        - Raises an error if the mean pixel value matches any value
+        - Return 'nan_value' if some pixels in the file have NaN values.
+        - Return 'no_data_only' if the mean pixel value matches any value
           in 'value_list', suggesting uniform pixel values across the file.
     """
-    image = dswx_sar_util.read_geotiff(geotiff_path)
-    mean_value = np.mean(image)
-    if np.isnan(mean_value):
-        raise ValueError(f'NaN pixels found in {geotiff_path}.')
-    elif np.isin(image, value_list).all():
-        raise ValueError(f'All pixels in {geotiff_path} are within the specified value list.')
+    image = dswx_sar_util.read_geotiff(geotiff_path)    
+    mean_value = np.nanmean(image)
+    print(f'checking {geotiff_path}')
+    validation_result = 'okay'
 
+    for invalid_value in value_list:
+        if np.any(image == invalid_value):
+            validation_result = 'invalid_found'
+            logger.warning(f'Some pixels in {geotiff_path} are within '\
+                           'the specified value list.')
+
+    if np.isnan(mean_value):
+        validation_result = 'nan_value'
+        logger.warning(f'NaN pixels found in {geotiff_path}.')
+    elif np.isin(image, value_list).all():
+        validation_result = 'invalid_only'
+        logger.warning(f'All pixels in {geotiff_path} are within '\
+                       'the specified invalid value list.')
+
+    return validation_result
 
 class AncillaryRelocation:
     '''
@@ -92,7 +106,8 @@ class AncillaryRelocation:
     def relocate(self,
                  ancillary_file_name,
                  relocated_file_str,
-                 method='near'):
+                 method='near',
+                 no_data=np.nan):
 
         """ resample image
 
@@ -109,12 +124,17 @@ class AncillaryRelocation:
                               ancillary_file_name,
                               os.path.join(self.scratch_dir,
                                            relocated_file_str),
-                              method)
+                              method,
+                              no_data=no_data)
+        dswx_sar_util._save_as_cog(
+            os.path.join(self.scratch_dir, relocated_file_str),
+                         self.scratch_dir)
 
     def _interpolate_gdal(self, ref_file,
                           input_tif_str,
                           output_tif_str,
-                          method):
+                          method,
+                          no_data):
 
         """Interpolate the input image to have same projection and resolution
         as the reference file.
@@ -171,7 +191,8 @@ class AncillaryRelocation:
                                yRes=yspacing,
                                outputBounds=[W, S, E, N],
                                resampleAlg=method,
-                               format='GTIFF')
+                               format='GTIFF',
+                               dstNodata=no_data)
 
         gdal.Warp(output_tif_str, input_tif_str, options=opt)
 
@@ -205,6 +226,78 @@ class AncillaryRelocation:
 
         return ycoord, xcoord
 
+
+def replace_reference_water_nodata_from_ancillary(
+        reference_water_path : str,
+        landcover_path : str,
+        hand_path : str,
+        reference_water_max : float,
+        reference_water_no_data : float,
+        line_per_block : int):
+    """
+    Replace no-data areas in a reference water raster 
+    with maximum values based on landcover and HAND data.
+
+    Parameters:
+    -----------
+    reference_water_path : str
+        Path to the reference water raster file.
+    landcover_path : str
+        Path to the landcover raster file.
+    hand_path : str
+        Path to the HAND raster file.
+    reference_water_max : float
+        Maximum value to replace no-data areas in the reference water raster.
+    reference_water_no_data : float
+        No-data value in the reference water raster.
+    lines_per_block : int
+        Number of lines per block for processing the raster data.
+    """
+    scratch_dir = os.path.dirname(reference_water_path)
+    temp_water_path = os.path.join(scratch_dir, 'temp_ref_water.tif')
+    shutil.copy2(reference_water_path, temp_water_path)
+
+    pad_shape = (0, 0)
+    im_meta = dswx_sar_util.get_meta_from_tif(reference_water_path)
+    block_params = dswx_sar_util.block_param_generator(
+        lines_per_block=line_per_block,
+        data_shape=(im_meta['length'],
+                    im_meta['width']),
+        pad_shape=pad_shape)
+
+    landcover_label = get_label_landcover_esa_10()
+
+    for block_param in block_params:
+        ref_water_block, landcover_block, hand_block = [
+            dswx_sar_util.get_raster_block(path, block_param)
+            for path in [temp_water_path,
+                         landcover_path, 
+                         hand_path]]
+
+        # Both invalid and no-water areas have zero value
+        # in reference water. The area with zero values are
+        # replaced with maximum values where the permanent water
+        # area in landcover.
+
+        replaced_area = np.logical_and(
+            ref_water_block == reference_water_no_data,
+            landcover_block == landcover_label['Permanent water bodies'])
+
+        no_data_area = np.logical_and(
+            ref_water_block == reference_water_no_data,
+            hand_block <= 0.002)
+        ref_water_block[no_data_area | replaced_area] = reference_water_max
+
+        # write updated reference water 
+        dswx_sar_util.write_raster_block(
+            out_raster=reference_water_path,
+            data=ref_water_block,
+            block_param=block_param,
+            geotransform=im_meta['geotransform'],
+            projection=im_meta['projection'],
+            datatype='float32')
+
+
 def run(cfg):
 
     logger.info("")
@@ -222,6 +315,8 @@ def run(cfg):
     dem_file = dynamic_data_cfg.dem_file
     hand_file = dynamic_data_cfg.hand_file
 
+    ref_water_max = processing_cfg.reference_water.max_value
+    ref_water_no_data = processing_cfg.reference_water.no_data_value
     pol_list = processing_cfg.polarizations
     pol_options = processing_cfg.polarimetric_option
     
@@ -263,7 +358,7 @@ def run(cfg):
             logger.error(err_str)
             raise ValueError(err_str)
 
-    logger.info(f'ancillary data is reprojected using {ref_filename}')
+    logger.info(f'Ancillary data is reprojected using {ref_filename}')
 
     pathlib.Path(scratch_dir).mkdir(parents=True, exist_ok=True)
     filtered_images_str = f"filtered_image_{pol_all_str}.tif"
@@ -276,59 +371,80 @@ def run(cfg):
     # create instance to relocate ancillary data
     ancillary_reloc = AncillaryRelocation(ref_filename, scratch_dir)
 
-    # Check if the interpolated water body file exists
-    wbd_interpolated_path = Path(
-        os.path.join(scratch_dir, 'interpolated_wbd.tif'))
+    # Note : landcover should precede before reference water.
+    relocated_ancillary_filename_set = {
+        'dem': 'interpolated_DEM.tif',
+        'hand': 'interpolated_hand.tif',
+        'landcover': 'interpolated_landcover.tif',
+        'reference_water': 'interpolated_wbd.tif',
+    }
 
-    if not wbd_interpolated_path.is_file():
-        logger.info('interpolated wbd file was not found')
-        ancillary_reloc.relocate(wbd_file,
-                                 'interpolated_wbd.tif',
-                                 method='near')
+    input_ancillary_filename_set = {
+        'dem': dem_file,
+        'hand': hand_file,
+        'landcover': landcover_file,
+        'reference_water': wbd_file,
+    }
 
-    # Check if the interpolated DEM exists
-    dem_interpolated_path = \
-        Path(scratch_dir) / 'interpolated_DEM.tif'
-    dem_reprocessing_flag = False
-    if not dem_interpolated_path.is_file():
-        logger.info('interpolated dem : not found ')
+    landcover_label = get_label_landcover_esa_10()
 
-        if os.path.isfile(dem_file):
-            logger.info('interpolated dem file was not found')
-            ancillary_reloc.relocate(dem_file,
-                                     'interpolated_DEM.tif',
-                                     method='near')
+    for anc_type, anc_filename in relocated_ancillary_filename_set.items():
+        input_anc_path = input_ancillary_filename_set[anc_type]
+        ancillary_path = Path(
+            os.path.join(scratch_dir, anc_filename))
+
+        # Check if input ancillary data is valid. 
+        if not os.path.isfile(dem_file):
+            err_msg = f'Input {anc_type} file not found'
+            raise FileNotFoundError(err_msg)
+
+        if anc_type in ['reference_water']:
+            no_data = ref_water_no_data
+        elif anc_type in ['landcover']:
+            no_data = landcover_label['No_data']
         else:
-            raise FileNotFoundError
+            no_data = np.nan
 
-    # check if interpolated DEM has valid values
-    if not dem_reprocessing_flag:
-        interpolated_dem_path = os.path.join(
-            scratch_dir, 'interpolated_DEM.tif')
-        validate_gtiff(interpolated_dem_path, [0])
+        # crop or relocate ancillary images to fit the reference 
+        # intensity (RTC) image. 
+        if not ancillary_path.is_file():
+            logger.info(f'Relocated {anc_type} file will be created from ' \
+                        f'{input_anc_path}.')
+            ancillary_reloc.relocate(
+                input_anc_path,
+                anc_filename,
+                method='near',
+                no_data=no_data)
 
-    # check if the interpolated landcover exists
-    landcover_interpolated_path = \
-        Path(scratch_dir) / 'interpolated_landcover.tif'
-    if not landcover_interpolated_path.is_file():
-        ancillary_reloc.relocate(landcover_file,
-                                 'interpolated_landcover.tif',
-                                 method='near')
+        # check if relocated ancillaries are filled with invalid values
+        validation_result = validate_gtiff(
+            os.path.join(scratch_dir, anc_filename),
+            [no_data, np.inf])
 
-    # Check if the interpolated HAND exists
-    hand_interpolated_path = os.path.join(
-        scratch_dir, 'interpolated_hand.tif')
-    if not os.path.isfile(hand_interpolated_path):
-        # Check if compuated HAND exists
-        if hand_file is None:
-            logger.info('>> HAND file is not found, so will be computed.')
-            # hand_calc.hand(dem_interpolated_path, args.scratch_dir)
-            # args.hand_file = os.path.join(args.scratch_dir, 'temp_hand.tif')
+        if validation_result not in 'okay':
+            if (anc_type in ['dem', 'hand']) and \
+                (validation_result in ['nan_value', 'invalid_only']):
+                err_msg = f'Unable to get valid {anc_type}'
+                raise ValueError(err_msg)
+    
+            elif anc_type in ['landcover']:
+                logger.warning(f'{anc_type} has invalid values.')
 
-        ancillary_reloc.relocate(hand_file,
-                                 'interpolated_hand.tif',
-                                 method='near')
-    del ancillary_reloc
+            elif anc_type in ['reference_water']:
+                logger.warning(f'{anc_type} has invalid values.')
+                # update reference water if any values of reference water
+                # are invalid.
+                replace_reference_water_nodata_from_ancillary(
+                    os.path.join(scratch_dir,
+                                 relocated_ancillary_filename_set['reference_water']),
+                    os.path.join(scratch_dir,
+                                 relocated_ancillary_filename_set['landcover']),
+                    os.path.join(scratch_dir,
+                                 relocated_ancillary_filename_set['hand']),
+                    reference_water_max=ref_water_max,
+                    reference_water_no_data=ref_water_no_data,
+                    line_per_block=line_per_block
+                )
 
     # apply SAR filtering
     pad_shape = (filter_size, 0)

--- a/src/dswx_sar/pre_processing.py
+++ b/src/dswx_sar/pre_processing.py
@@ -51,7 +51,7 @@ def validate_gtiff(geotiff_path, value_list):
     Returns
     -------
     validation_result: str
-        If any of the checks fail, return bool indicating potential issues
+        If any of the checks fail, return a string that indicates potential issues
         with the GeoTIFF file.
         - Return 'nan_value' if some pixels in the file have NaN values.
         - Return 'invalid_only' if the mean pixel value matches any value

--- a/src/dswx_sar/region_growing.py
+++ b/src/dswx_sar/region_growing.py
@@ -281,7 +281,9 @@ def run_parallel_region_growing(input_tif_path,
                 block_param,
                 geotransform=meta_dict['geotransform'],
                 projection=meta_dict['projection'],
-                datatype='float32')
+                datatype='float32',
+                cog_flag=True,
+                scratch_dir=base_dir)
 
             # In final loop, write the result to output_tif_path
             if loopind == num_loop - 1:
@@ -291,7 +293,9 @@ def run_parallel_region_growing(input_tif_path,
                     block_param,
                     geotransform=meta_dict['geotransform'],
                     projection=meta_dict['projection'],
-                    datatype='float32')
+                    datatype='float32',
+                    cog_flag=True,
+                    scratch_dir=base_dir)
 
 
 def run(cfg):


### PR DESCRIPTION
This PR adds the sanity checker for the ancillary data and also adds the functions to replace the no-data value with the water pixel in the reference water map where the ocean area is located. This improves the runtime in the region-growing step. 