### PR TITLE
Add support for GDAL raster files in AWS S3

### DIFF
--- a/src/dswx_sar/dswx_runconfig.py
+++ b/src/dswx_sar/dswx_runconfig.py
@@ -170,10 +170,14 @@ def check_file_path(file_path: str) -> None:
     file_path : str
         Path to file to be checked
     """
-    if not os.path.exists(file_path):
-        err_str = f'{file_path} not found'
-        logger.error(err_str)
-        raise FileNotFoundError(err_str)
+    if file_path.startswith('/vsis3/'):
+        check_gdal_raster_s3(file_path, raise_error=True)
+
+    else:
+        if not os.path.exists(file_path):
+            err_str = f'{file_path} not found'
+            logger.error(err_str)
+            raise FileNotFoundError(err_str)
 
 def _find_polarization_from_data_dirs(input_dir_list):
     """
@@ -311,10 +315,7 @@ def validate_group_dict(group_cfg: dict) -> None:
                             ref_water_path, hand_path]
 
     for path in ancillary_file_paths:
-        if path.startswith('/vsis3/'):
-            check_gdal_raster_s3(path)
-        else:
-            check_file_path(path)
+        check_file_path(path)
 
     # Check 'product_group' section of runconfig.
     # Check that directories herein have writing permissions

--- a/src/dswx_sar/dswx_runconfig.py
+++ b/src/dswx_sar/dswx_runconfig.py
@@ -11,6 +11,7 @@ import yamale
 from ruamel.yaml import YAML
 
 import dswx_sar
+from dswx_sar.dswx_sar_util import check_gdal_raster_s3
 
 logger = logging.getLogger('dswx-s1')
 
@@ -310,7 +311,9 @@ def validate_group_dict(group_cfg: dict) -> None:
                             ref_water_path, hand_path]
 
     for path in ancillary_file_paths:
-        if not path.startswith('/vsis3/'):
+        if path.startswith('/vsis3/'):
+            check_gdal_raster_s3(path)
+        else:
             check_file_path(path)
 
     # Check 'product_group' section of runconfig.

--- a/src/dswx_sar/dswx_runconfig.py
+++ b/src/dswx_sar/dswx_runconfig.py
@@ -205,7 +205,8 @@ def validate_group_dict(group_cfg: dict) -> None:
                             ref_water_path, hand_path]
 
     for path in ancillary_file_paths:
-        check_file_path(path)
+        if not path.startswith('/vsis3/'):
+            check_file_path(path)
 
     # Check 'product_group' section of runconfig.
     # Check that directories herein have writing permissions

--- a/src/dswx_sar/dswx_sar_util.py
+++ b/src/dswx_sar/dswx_sar_util.py
@@ -923,3 +923,36 @@ def block_threshold_visulaization_rg(intensity, threshold_dict, outputdir, figna
         # Save the visualization to file
         plt.savefig(os.path.join(outputdir, f'{figname}_{band_index}'))
         plt.close()
+
+
+def check_gdal_raster_s3(path_raster_s3: str, raise_error=True):
+    '''
+    Check if the GDAL raster in S3 bucket is available
+
+    Parameter
+    ---------
+    path_raster_s3: str
+        Path to the GDAL raster in S3 bucket starts with `/vsis3`
+    raise_error: bool
+        Raise an error when the file is not accessible, rather than
+        returning a boolean flag
+
+    Returns
+    -------
+    _: Bool
+        True when the file is accessible; False otherwise
+    '''
+    if not path_raster_s3.startswith('/vsis3/'):
+        raise RuntimeError(f'The raster path {path_raster_s3} is not a '
+                           'valid format for GDAL raster in S3 bucket')
+
+    # Currently `gdal.DontUseExceptions()` is called in this code.
+    # In that case, failed `gdal.Open()` will return None
+    gdal_in = gdal.Open(path_raster_s3)
+
+    is_gdal_file_exist = gdal_in is not None
+
+    if not is_gdal_file_exist and raise_error:
+        raise FileNotFoundError(path_raster_s3)
+
+    return is_gdal_file_exist

--- a/src/dswx_sar/dswx_sar_util.py
+++ b/src/dswx_sar/dswx_sar_util.py
@@ -941,6 +941,12 @@ def check_gdal_raster_s3(path_raster_s3: str, raise_error=True):
     -------
     _: Bool
         True when the file is accessible; False otherwise
+
+    Raises
+    ------
+    RuntimeError
+        When the GDAL raster in AWS S3 is not available.
+        Optional when the parameter `raise_error` is `True`.
     '''
     if not path_raster_s3.startswith('/vsis3/'):
         raise RuntimeError(f'The raster path {path_raster_s3} is not a '
@@ -953,6 +959,6 @@ def check_gdal_raster_s3(path_raster_s3: str, raise_error=True):
     is_gdal_file_exist = gdal_in is not None
 
     if not is_gdal_file_exist and raise_error:
-        raise FileNotFoundError(path_raster_s3)
+        raise RuntimeError(f'GDAL raster "{path_raster_s3}" is not available.')
 
     return is_gdal_file_exist

--- a/src/dswx_sar/dswx_sar_util.py
+++ b/src/dswx_sar/dswx_sar_util.py
@@ -940,7 +940,8 @@ def check_gdal_raster_s3(path_raster_s3: str, raise_error=True):
     Returns
     -------
     _: Bool
-        True when the file is accessible; False otherwise
+        True when the file is accessible; False otherwise.
+        Optional when the parameter `raise_error` is `False`.
 
     Raises
     ------

--- a/src/dswx_sar/filter_SAR.py
+++ b/src/dswx_sar/filter_SAR.py
@@ -1,7 +1,7 @@
 import numpy as np
 from scipy import signal
 
-from dswx_sar_util import Constants
+from  dswx_sar.dswx_sar_util import Constants
 
 K_DEFAULT = 1.0
 CU_DEFAULT = 0.523

--- a/src/dswx_sar/mosaic_rtc_burst.py
+++ b/src/dswx_sar/mosaic_rtc_burst.py
@@ -764,19 +764,8 @@ def run(cfg):
         epsg_list = []
 
         for ind, input_dir in enumerate(input_list):
-            try:
-                first_rtc_path_iter = glob.iglob(f'{input_dir}/*_{first_pol}.tif')
-                first_rtc_path = next(first_rtc_path_iter)
-            except:
-                print('Switching Polarization to find RTC-S1 product')
-                pol_list = _switch_pol(pol_list)
-                cfg.groups.processing.polarizations = pol_list
-                first_pol = pol_list[0]
 
-                first_rtc_path_iter = glob.iglob(f'{input_dir}/*_{first_pol}.tif')
-                first_rtc_path = next(first_rtc_path_iter)
-
-            first_rtc_path_iter = glob.iglob(f'{input_dir}/*.tif')
+            first_rtc_path_iter = glob.iglob(f'{input_dir}/*_{first_pol}.tif')
             first_rtc_path = next(first_rtc_path_iter)
             if first_rtc_path:
                 rtc_meta = dswx_sar_util.get_meta_from_tif(first_rtc_path)

--- a/src/dswx_sar/mosaic_rtc_burst.py
+++ b/src/dswx_sar/mosaic_rtc_burst.py
@@ -765,7 +765,7 @@ def run(cfg):
 
         for ind, input_dir in enumerate(input_list):
 
-            first_rtc_path_iter = glob.iglob(f'{input_dir}/*_{first_pol}.tif')
+            first_rtc_path_iter = glob.iglob(f'{input_dir}/*.tif')
             first_rtc_path = next(first_rtc_path_iter)
             if first_rtc_path:
                 rtc_meta = dswx_sar_util.get_meta_from_tif(first_rtc_path)

--- a/src/dswx_sar/mosaic_rtc_burst.py
+++ b/src/dswx_sar/mosaic_rtc_burst.py
@@ -792,6 +792,7 @@ def run(cfg):
             except:
                 print('Switching Polarization to find RTC-S1 product')
                 pol_list = _switch_pol(pol_list)
+                cfg.groups.processing.polarizations = pol_list
                 first_pol = pol_list[0]
 
                 first_rtc_path_iter = glob.iglob(f'{input_dir}/*_{first_pol}.tif')

--- a/src/dswx_sar/pre_processing.py
+++ b/src/dswx_sar/pre_processing.py
@@ -13,7 +13,7 @@ from dswx_sar import dswx_sar_util, filter_SAR, generate_log
 from dswx_sar.dswx_runconfig import (DSWX_S1_POL_DICT,
                                      _get_parser,
                                      RunConfig)
-
+from dswx_sar.dswx_sar_util import check_gdal_raster_s3
 
 logger = logging.getLogger('dswx_s1')
 
@@ -293,7 +293,7 @@ def run(cfg):
     if not dem_interpolated_path.is_file():
         logger.info('interpolated dem : not found ')
 
-        if os.path.isfile(dem_file) or dem_file.startswith('/vsis3/'):
+        if os.path.isfile(dem_file) or check_gdal_raster_s3(dem_file, raise_error=False):
             logger.info('interpolated dem file was not found')
             ancillary_reloc.relocate(dem_file,
                                      'interpolated_DEM.tif',

--- a/src/dswx_sar/pre_processing.py
+++ b/src/dswx_sar/pre_processing.py
@@ -253,7 +253,7 @@ def run(cfg):
     if not dem_interpolated_path.is_file():
         logger.info('interpolated dem : not found ')
 
-        if os.path.isfile(dem_file):
+        if os.path.isfile(dem_file) or dem_file.startswith('/vsis3/'):
             logger.info('interpolated dem file was not found')
             ancillary_reloc.relocate(dem_file,
                                      'interpolated_DEM',


### PR DESCRIPTION
This PR adds support to use the ancillary data located in AWS S3 bucket. GDAL can access them with the prefix `/vsis3`, provided that the permission & credential to the corresponding S3 bucket is properly set. This branch has been updated in line with the scale-up processing on AWS, but I think it would be better to merge this branch to the main sooner than later so that we can avoid too much deviation.

Another issue that this PR covers is the importing `constants` in absolute path. Looks like that change is similar as in duplication with #43. I appreciate the information provided by @cmarshak, and glad to see that we've come up with the similar solution. The change in my branch has committed in [11/28/2023](https://github.com/opera-adt/DSWX-SAR/commit/5b07df6382fe46ccfccba42cac64e727b1802c10), which I think is before that PR.