### PR TITLE
Apply compression to the warped GDAL rasters

### DIFF
--- a/src/dswx_sar/mosaic_rtc_burst.py
+++ b/src/dswx_sar/mosaic_rtc_burst.py
@@ -134,7 +134,9 @@ def save_h5_metadata_to_tif(h5_meta_path,
                      xRes=xres,
                      yRes=abs(yres),
                      resampleAlg='nearest',
-                     format='GTIFF')
+                     format='GTIFF',
+                     creationOptions=['COMPRESS=DEFLATE',
+                                      'PREDICTOR=2'])
         gdal.Warp(output_tif_path, output_tif_temp_path, options=opt)
         os.remove(output_tif_temp_path)
 
@@ -412,6 +414,10 @@ def compute_mosaic_array(list_rtc_images, list_nlooks, mosaic_mode, scratch_dir=
 
             if temp_files_list is not None:
                 temp_files_list.append(relocated_file)
+            
+            warp_creation_options = gdal.WarpOptions(
+                creationOptions=['COMPRESS=DEFLATE',
+                                 'PREDICTOR=2'])
 
             gdal.Warp(relocated_file, path_rtc,
                         format='GTiff',
@@ -428,7 +434,8 @@ def compute_mosaic_array(list_rtc_images, list_nlooks, mosaic_mode, scratch_dir=
                         yRes=abs(geogrid_in.spacing_y),
                         resampleAlg='average',
                         errorThreshold=0,
-                        dstNodata=np.nan)
+                        dstNodata=np.nan,
+                        options=warp_creation_options)
             path_rtc = relocated_file
 
             if path_nlooks is not None:


### PR DESCRIPTION
This PR is to apply the compression to the saved GEOTIFFS to save disk space during the processing. AWS instance can be terminated when the disk usage is over the limit. This PR would be helpful to reduce the disk usage when reproduction takes place during the mosaicking procedure, so that the stability of SAS can be improved especially when it is running on EC2 instances with not-so-big EBS.