### PR TITLE
Add a function adjusting threshold

### DIFF
--- a/src/dswx_sar/defaults/algorithm_parameter_s1.yaml
+++ b/src/dswx_sar/defaults/algorithm_parameter_s1.yaml
@@ -82,8 +82,7 @@ runconfig:
             # Number of threads to run
             # -1 represents the all available threads
             number_cpu: -1
-            number_iterations: 1
-            tile_average: False
+            tile_average: True
             line_per_block: 300
 
         fuzzy_value:

--- a/src/dswx_sar/defaults/algorithm_parameter_s1.yaml
+++ b/src/dswx_sar/defaults/algorithm_parameter_s1.yaml
@@ -77,7 +77,8 @@ runconfig:
             # estimate single threshold per tile. If True, the trimodal distribution is assumed,
             # the lowest threshold is estimated.
             multi_threshold: True
-
+            # Flag to adjust threshold where two gaussian distribution is not overlapped. 
+            adjust_threshold_nonoverlapped_distribution: True
             # Number of threads to run
             # -1 represents the all available threads
             number_cpu: -1

--- a/src/dswx_sar/dswx_sar_util.py
+++ b/src/dswx_sar/dswx_sar_util.py
@@ -865,7 +865,7 @@ def block_threshold_visualization(intensity, block_row, block_col,
     plt.close()
 
 
-def block_threshold_visulaization_rg(intensity, threshold_dict, outputdir, figname):
+def block_threshold_visualization_rg(intensity, threshold_dict, outputdir, figname):
     """
     Visualize an intensity image overlaid with threshold values from provided blocks/subtiles.
 

--- a/src/dswx_sar/initial_threshold.py
+++ b/src/dswx_sar/initial_threshold.py
@@ -273,7 +273,7 @@ class TileSelection:
                            intensity,
                            water_mask,
                            win_size=200,
-                           selection_method=['combined'],
+                           selection_methods=['combined'],
                            mininum_tile=20,
                            minimum_pixel_number=40):
         '''Select the tile candidates containing water and non-water
@@ -291,7 +291,7 @@ class TileSelection:
         win_size : integer
             size of window to search the water body that should be smaller
             than size of intensity
-        selection_method : list
+        selection_methods : list
             window type {twele, chini, bimodality, combined}
             'combined' method runs all methods
 
@@ -425,8 +425,7 @@ class TileSelection:
                                 # Initially set flag as True
                                 tile_selected_flag = True
 
-                                if any(item in ['twele', 'combined']
-                                       for item in selection_method):
+                                if {'twele', 'combined'}.intersection(set(selection_methods)):
                                     tile_selected_flag, _, _ = \
                                         self.select_tile_twele(
                                             intensity_sub_gray,
@@ -438,12 +437,11 @@ class TileSelection:
                                 else:
                                     selected_tile_twele.append(False)
 
-                                if any(item in ['chini', 'combined']
-                                       for item in selection_method):
+                                if {'chini', 'combined'}.intersection(set(selection_methods)):
                                     # Once 'combined' method is selected,
                                     # the chini test is carried when the
                                     # 'twele' method passed.
-                                    if (selection_method in ['combined']) & \
+                                    if (selection_methods in ['combined']) & \
                                         (not tile_selected_flag):
 
                                         selected_tile_chini.append(False)
@@ -460,10 +458,9 @@ class TileSelection:
                                 else:
                                     selected_tile_chini.append(False)
 
-                                if any(item in ['bimodality', 'combined']
-                                       for item in selection_method):
+                                if {'bimodality', 'combined'}.intersection(set(selection_methods)):
 
-                                    if (selection_method == 'combined') and \
+                                    if (selection_methods == 'combined') and \
                                         not tile_selected_flag:
 
                                         selected_tile_bimodality.append(False)
@@ -493,7 +490,7 @@ class TileSelection:
                                  y_start, y_end])
                             ind_subtile += 1
 
-                    if 'combined' in selection_method:
+                    if 'combined' in selection_methods:
                         selected_tile_merged = np.logical_and(
                             selected_tile_twele,
                             selected_tile_chini)
@@ -505,16 +502,16 @@ class TileSelection:
                         # Initialize the result array with False values
                         detected_box_array = np.ones_like(selected_tile_twele,
                                                           dtype=bool)
-                        # Check and aggregate the results based on the selection_method
-                        if 'twele' in selection_method:
+                        # Check and aggregate the results based on the selection_methods
+                        if 'twele' in selection_methods:
                             detected_box_array = np.logical_and(
                                 detected_box_array,
                                 selected_tile_twele)
-                        if 'chini' in selection_method:
+                        if 'chini' in selection_methods:
                             detected_box_array = np.logical_and(
                                 detected_box_array,
                                 selected_tile_chini)
-                        if 'bimodality' in selection_method:
+                        if 'bimodality' in selection_methods:
                             detected_box_array = np.logical_and(
                                 detected_box_array,
                                 selected_tile_bimodality)
@@ -530,7 +527,7 @@ class TileSelection:
             else:
                 logger.info('No water body found')
 
-            if 'combined' in selection_method:
+            if 'combined' in selection_methods:
                 selected_tile = np.logical_and(
                     selected_tile_twele,
                     selected_tile_chini)
@@ -1624,7 +1621,7 @@ def run_sub_block(intensity, wbdsub, cfg, winsize=200, thres_max=[-15, -22]):
                            intensity=intensity[polind, :, :],
                            water_mask=wbdsub,
                            win_size=winsize,
-                           selection_method=tile_selection_method)
+                           selection_methods=tile_selection_method)
 
         if pol in ['VV', 'VH', 'HH', 'HV', 'span']:
             min_intensity_histogram, max_intensity_histogram, step_histogram = -35, 10, 0.1

--- a/src/dswx_sar/initial_threshold.py
+++ b/src/dswx_sar/initial_threshold.py
@@ -1207,7 +1207,7 @@ def optimize_inter_distribution_threshold(
     """
     # Adjust the threshold if the distributions do not overlap
     iteration = 0
-    while (norm.cdf(threshold, mean1, std1) < 0.95 or norm.cdf(threshold, mean2, std2) < 0.05) \
+    while (norm.cdf(threshold, mean1, std1) < 0.95 and norm.cdf(threshold, mean2, std2) < 0.05) \
         and iteration < max_iterations:
         # Move threshold towards the mean of the second distribution
         threshold += (mean2 - threshold) * step_fraction

--- a/src/dswx_sar/initial_threshold.py
+++ b/src/dswx_sar/initial_threshold.py
@@ -2193,8 +2193,24 @@ def run(cfg):
                         no_data=-50,
                         average_tile=average_threshold_flag)
 
-        # create initial map for iteration method
     if processing_cfg.debug_mode:
+
+        intensity_whole = dswx_sar_util.read_geotiff(filt_im_str)
+        if not average_threshold_flag:
+            dswx_sar_util.block_threshold_visualization_rg(
+                intensity_whole,
+                threshold_tau_dict,
+                outputdir=outputdir,
+                figname=f'int_threshold_visualization_')
+        else:
+            for band_ind2 in range(band_number):
+                dswx_sar_util.block_threshold_visualization(
+                    np.squeeze(intensity_whole[band_ind2, :, :]),
+                    block_row,
+                    block_col,
+                    threshold_tau_set[:, :, band_ind2],
+                    outputdir,
+                    f'int_threshold_visualization_{pol_list[band_ind2]}')
 
         data_shape = (height, width)
         pad_shape = (0, 0)

--- a/src/dswx_sar/initial_threshold.py
+++ b/src/dswx_sar/initial_threshold.py
@@ -2134,11 +2134,11 @@ def run(cfg):
                                 (sub_window[1] + sub_window[2]) / 2)
                                 for sub_window in window_coord]
 
-                        window_center_col_list = [int(jj * block_col +
-                                                    (sub_window[3] +
-                                                    sub_window[4])/2)
-                                                for sub_window in
-                                                window_coord]
+                        window_center_col_list = [
+                            int(jj * block_col + 
+                                (sub_window[3] + sub_window[4]) / 2)
+                                for sub_window in window_coord]
+
                         # window coordinates
                         absolute_window_coord = [
                             [ii * block_row + sub_window[1],
@@ -2147,10 +2147,11 @@ def run(cfg):
                              jj * block_col + sub_window[4]]
                                 for sub_window in window_coord]
 
-                        coord_row_list[pol_index] = coord_row_list[pol_index] + \
-                            window_center_row_list
-                        coord_col_list[pol_index] = coord_col_list[pol_index] + \
-                            window_center_col_list
+                        coord_row_list[pol_index] = \
+                            coord_row_list[pol_index] + window_center_row_list
+                        coord_col_list[pol_index] = \
+                            coord_col_list[pol_index] + window_center_col_list
+
                         threshold_tau_set[pol_index].extend(threshold_tau_subset[0])
                         mode_tau_set[pol_index].extend(mode_tau_subset[0])
                         window_coord_list[pol_index].extend(

--- a/src/dswx_sar/initial_threshold.py
+++ b/src/dswx_sar/initial_threshold.py
@@ -2067,15 +2067,16 @@ def run(cfg):
         n_jobs = number_workers
 
         results = Parallel(n_jobs=n_jobs)(
-            delayed(process_block)(ii, jj,
-                                n_rows_block, n_cols_block,
-                                m_rows_block, m_cols_block,
-                                block_row, block_col,
-                                width, filt_im_str,
-                                water_mask_tif_str, cfg,
-                                thres_max, average_threshold_flag)
-            for ii in range(0, n_rows_block)
-            for jj in range(0, n_cols_block)
+            delayed(process_block)(
+                ii, jj,
+                n_rows_block, n_cols_block,
+                m_rows_block, m_cols_block,
+                block_row, block_col,
+                width, filt_im_str,
+                water_mask_tif_str, cfg,
+                thres_max, average_threshold_flag)
+                for ii in range(0, n_rows_block)
+                for jj in range(0, n_cols_block)
             )
 
         # If average_threshold_flag is True, all thresholds within
@@ -2128,11 +2129,10 @@ def run(cfg):
 
                     if threshold_tau_subset:
                         # window center for row and col
-                        window_center_row_list = [int(ii * block_row +
-                                                    (sub_window[1] +
-                                                    sub_window[2])/2)
-                                                for sub_window in
-                                                window_coord]
+                        window_center_row_list = [
+                            int(ii * block_row + 
+                                (sub_window[1] + sub_window[2]) / 2)
+                                for sub_window in window_coord]
 
                         window_center_col_list = [int(jj * block_col +
                                                     (sub_window[3] +
@@ -2140,16 +2140,13 @@ def run(cfg):
                                                 for sub_window in
                                                 window_coord]
                         # window coordinates
-                        absolute_window_coord = [[ii * block_row +
-                                                sub_window[1],
-                                                ii * block_row +
-                                                sub_window[2],
-                                                jj * block_col +
-                                                sub_window[3],
-                                                jj * block_col +
-                                                sub_window[4]]
-                                                for sub_window in
-                                                window_coord]
+                        absolute_window_coord = [
+                            [ii * block_row + sub_window[1],
+                             ii * block_row + sub_window[2],
+                             jj * block_col + sub_window[3],
+                             jj * block_col + sub_window[4]]
+                                for sub_window in window_coord]
+
                         coord_row_list[pol_index] = coord_row_list[pol_index] + \
                             window_center_row_list
                         coord_col_list[pol_index] = coord_col_list[pol_index] + \

--- a/src/dswx_sar/schemas/algorithm_parameter_s1.yaml
+++ b/src/dswx_sar/schemas/algorithm_parameter_s1.yaml
@@ -76,7 +76,6 @@ runconfig:
             # Flag to average the thresholds within the tile.
             # The output thresholds are assigned to each tile.
             tile_average: bool(required=False)
-            number_iterations: num(required=False)
             # Number of threads to run
             # -1 represents the all available threads
             number_cpu: num(required=False)

--- a/src/dswx_sar/schemas/algorithm_parameter_s1.yaml
+++ b/src/dswx_sar/schemas/algorithm_parameter_s1.yaml
@@ -49,7 +49,7 @@ runconfig:
             # Tile selecting strategy to identify the boundary between water and nonwater
             # ['twele', 'chini', 'bimodality', 'combined']
             # 'combined' option applies all selection strategy
-            selection_method: str(required=False)
+            selection_method: list(enum('twele', 'chini', 'bimodality', 'combined'), min=1, max=3, required=False)
             # Thresholds to select tiles showing the boundary between water and nonwater
             # three values are required for twele method
             # 1) std / mean of tiles
@@ -71,6 +71,8 @@ runconfig:
             # estimate single threshold per tile. If True, the trimodal distribution is assumed,
             # the lowest threshold is estimated.
             multi_threshold: bool(required=False)
+            # Flag to adjust threshold where two gaussian distribution is not overlapped. 
+            adjust_threshold_nonoverlapped_distribution: bool(required=False)
             # Flag to average the thresholds within the tile.
             # The output thresholds are assigned to each tile.
             tile_average: bool(required=False)


### PR DESCRIPTION
This PR includes several modifications to the `initial_threshold.py` file, aimed at improving its functionality.

1) **The `optimize_inter_distribution_threshold` is introduced.** 
This function addresses situations where the two distributions do not overlap. In such cases, the threshold tends to be biased towards the lower distribution (see figure), which can help reduce false positives (dark land) but may increase false negatives (bright water). To achieve a more balanced threshold, the `optimize_inter_distribution_threshold function` is introduced. It adjusts the threshold slightly higher when it falls below the 95% tail of the left distribution and the 5% tail of the right distribution. This adjustment helps mitigate false positive issues.

![image](https://github.com/opera-adt/DSWX-SAR/assets/56169931/61bcb37c-78fb-4392-8a6f-ab5b2eff18ec)

2) **The tile-selection has more freedom to choose.** 
In the previous version, users had options for tile-selection methods, including `twele`, `chini`, `bimodality`, and `combined`. The `combined` method combined all available methods (`twele, chini, bimodality`). However, there was a limitation in the previous version where users could only choose the selective methods, which included only two individual methods. With this PR, users can now select any two of the individual methods, such as `chini` and `bimodality` allowing for a more customized tile-selection approach.

3) **`iteration` in `initial_threshold` was deleted.** 
This change was made because it was found that the iteration parameter did not result in any improvements in the function's performance. Although this change may seem minor, it had an impact on the code's indentation without altering the underlying functionality.
