### PR TITLE
Antimeridian crossing

### DIFF
--- a/src/dswx_sar/pre_processing.py
+++ b/src/dswx_sar/pre_processing.py
@@ -6,9 +6,10 @@ import numpy as np
 import os
 import pathlib
 import shutil
+import tempfile
 import time
 
-from osgeo import gdal, osr
+from osgeo import gdal, osr, ogr
 from pathlib import Path
 
 from dswx_sar import dswx_sar_util, filter_SAR, generate_log
@@ -104,7 +105,12 @@ class AncillaryRelocation:
             self._read_x_y_array_geotiff(rtc_file_name)
         reftif = gdal.Open(rtc_file_name)
         proj = osr.SpatialReference(wkt=reftif.GetProjection())
+        self.projection = reftif.GetProjection()
+        self.geotransform = reftif.GetGeoTransform()
+
         self.epsg = proj.GetAttrValue('AUTHORITY',1)
+        self.xsize = reftif.RasterXSize
+        self.ysize = reftif.RasterYSize
         self.scratch_dir = scratch_dir
 
     def relocate(self,
@@ -124,12 +130,23 @@ class AncillaryRelocation:
         method : str
             interpolation method
         """
-        self._interpolate_gdal(str(self.rtc_file_name),
-                              ancillary_file_name,
-                              os.path.join(self.scratch_dir,
-                                           relocated_file_str),
-                              method,
-                              no_data=no_data)
+        self._warp(
+            ancillary_file_name,
+            self.geotransform,
+            self.projection,
+            self.ysize, self.xsize,
+            scratch_dir = self.scratch_dir,
+            resample_algorithm='nearest',
+            relocated_file=os.path.join(self.scratch_dir,
+                                        relocated_file_str),
+            margin_in_pixels=0,
+            temp_files_list = None)
+        # self._interpolate_gdal(str(self.rtc_file_name),
+        #                       ancillary_file_name,
+        #                       os.path.join(self.scratch_dir,
+        #                                    relocated_file_str),
+        #                       method,
+        #                       no_data=no_data)
         dswx_sar_util._save_as_cog(
             os.path.join(self.scratch_dir, relocated_file_str),
                          self.scratch_dir)
@@ -201,6 +218,287 @@ class AncillaryRelocation:
         gdal.Warp(output_tif_str, input_tif_str, options=opt)
 
 
+    def _get_tile_srs_bbox(self, 
+                           tile_min_y_utm, tile_max_y_utm,
+                        tile_min_x_utm, tile_max_x_utm,
+                        tile_srs, polygon_srs):
+        """Get tile bounding box for a given spatial reference system (SRS)
+
+        Parameters
+        ----------
+        tile_min_y_utm: float
+                Tile minimum Y-coordinate (UTM)
+        tile_max_y_utm: float
+                Tile maximum Y-coordinate (UTM)
+        tile_min_x_utm: float
+                Tile minimum X-coordinate (UTM)
+        tile_max_x_utm: float
+                Tile maximum X-coordinate (UTM)
+        tile_srs: osr.SpatialReference
+                Tile original spatial reference system (SRS)
+        polygon_srs: osr.SpatialReference
+                Polygon spatial reference system (SRS). If the polygon
+                SRS is geographic, its Axis Mapping Strategy will
+                be updated to osr.OAMS_TRADITIONAL_GIS_ORDER
+        Returns
+        -------
+        tile_polygon: ogr.Geometry
+                Rectangle representing polygon SRS bounding box
+        tile_min_y: float
+                Tile minimum Y-coordinate (polygon SRS)
+        tile_max_y: float
+                Tile maximum Y-coordinate (polygon SRS)
+        tile_min_x: float
+                Tile minimum X-coordinate (polygon SRS)
+        tile_max_x: float
+                Tile maximum X-coordinate (polygon SRS)
+        """
+
+        # forces returned values from TransformPoint() to be (x, y, z)
+        # rather than (y, x, z) for geographic SRS
+        if polygon_srs.IsGeographic():
+            try:
+                polygon_srs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+            except AttributeError:
+                logger.warning('WARNING Could not set the ancillary input SRS axis'
+                            ' mapping strategy (SetAxisMappingStrategy())'
+                            ' to osr.OAMS_TRADITIONAL_GIS_ORDER')
+        transformation = osr.CoordinateTransformation(tile_srs, polygon_srs)
+
+        elevation = 0
+        tile_x_array = np.zeros((4))
+        tile_y_array = np.zeros((4))
+        tile_x_array[0], tile_y_array[0], z = transformation.TransformPoint(
+            tile_min_x_utm, tile_max_y_utm, elevation)
+        tile_x_array[1], tile_y_array[1], z = transformation.TransformPoint(
+            tile_max_x_utm, tile_max_y_utm, elevation)
+        tile_x_array[2], tile_y_array[2], z = transformation.TransformPoint(
+            tile_max_x_utm, tile_min_y_utm, elevation)
+        tile_x_array[3], tile_y_array[3], z = transformation.TransformPoint(
+            tile_min_x_utm, tile_min_y_utm, elevation)
+        print('tile_coord x', tile_x_array)
+        print('tile_coord y', tile_y_array)
+        tile_min_y = np.min(tile_y_array)
+        tile_max_y = np.max(tile_y_array)
+        tile_min_x = np.min(tile_x_array)
+        tile_max_x = np.max(tile_x_array)
+
+        # handles antimeridian: tile_max_x around +180 and tile_min_x around -180
+        # add 360 to tile_min_x, so it becomes a little greater than +180
+        if tile_max_x > tile_min_x + 340:
+            tile_min_x = np.max(tile_x_array[tile_x_array<-150])
+            tile_max_x = np.min(tile_x_array[tile_x_array>150])
+            tile_min_x, tile_max_x = tile_max_x, tile_min_x + 360
+
+        tile_ring = ogr.Geometry(ogr.wkbLinearRing)
+        tile_ring.AddPoint(tile_min_x, tile_max_y)
+        tile_ring.AddPoint(tile_max_x, tile_max_y)
+        tile_ring.AddPoint(tile_max_x, tile_min_y)
+        tile_ring.AddPoint(tile_min_x, tile_min_y)
+        tile_ring.AddPoint(tile_min_x, tile_max_y)
+        tile_polygon = ogr.Geometry(ogr.wkbPolygon)
+        tile_polygon.AddGeometry(tile_ring)
+        tile_polygon.AssignSpatialReference(polygon_srs)
+        return tile_polygon, tile_min_y, tile_max_y, tile_min_x, tile_max_x
+
+
+    def _warp(
+            self, 
+            input_file, geotransform, projection,
+            length, width,
+            scratch_dir = '.',
+            resample_algorithm='nearest',
+            relocated_file=None, margin_in_pixels=0,
+            temp_files_list = None):
+        """Relocate/reproject a file (e.g., landcover or DEM) based on geolocation
+        defined by a geotransform, output dimensions (length and width)
+        and projection
+
+        Parameters
+        ----------
+        input_file: str
+                Input filename
+        geotransform: numpy.ndarray
+                Geotransform describing the output file geolocation
+        projection: str
+                Output file's projection
+        length: int
+                Output length before adding the margin defined by
+                `margin_in_pixels`
+        width: int
+                Output width before adding the margin defined by
+                `margin_in_pixels`
+        scratch_dir: str (optional)
+                Directory for temporary files
+        resample_algorithm: str
+                Resample algorithm
+        relocated_file: str
+                Relocated file (output file)
+        margin_in_pixels: int
+                Margin in pixels (default: 0)
+        temp_files_list: list (optional)
+                Mutable list of temporary files. If provided,
+                paths to the temporary files generated will be
+                appended to this list.
+
+        Returns
+        -------
+        relocated_array : numpy.ndarray
+                Relocated array
+        """
+
+        # Pixel spacing
+        dy = geotransform[5]
+        dx = geotransform[1]
+
+        # Output Y-coordinate start (North) position with margin
+        tile_max_y_utm = geotransform[3] - margin_in_pixels * dy
+
+        # Output X-coordinate start (West) position with margin
+        tile_min_x_utm = geotransform[0] - margin_in_pixels * dx
+
+        # Output Y-coordinate end (South) position with margin
+        tile_min_y_utm = tile_max_y_utm + (length + 2 * margin_in_pixels) * dy
+
+        # Output X-coordinate end (East) position with margin
+        tile_max_x_utm = tile_min_x_utm + (width + 2 * margin_in_pixels) * dx
+
+        # Set output spatial reference system (SRS) from projection
+        tile_srs_str = get_projection_proj4(projection)
+        tile_srs = osr.SpatialReference()
+        tile_srs.ImportFromProj4(projection)
+
+        if relocated_file is None:
+            relocated_file = tempfile.NamedTemporaryFile(
+                        dir=scratch_dir, suffix='.tif').name
+            if temp_files_list is not None:
+                temp_files_list.append(relocated_file)
+
+        os.makedirs(scratch_dir, exist_ok=True)
+
+        # Test for antimeridian ("dateline") crossing
+        gdal_ds = gdal.Open(input_file, gdal.GA_ReadOnly)
+        file_projection = gdal_ds.GetProjection()
+
+        file_geotransform = gdal_ds.GetGeoTransform()
+        file_min_x, file_dx, _, file_max_y, _, file_dy = file_geotransform
+
+        file_width = gdal_ds.GetRasterBand(1).XSize
+        file_length = gdal_ds.GetRasterBand(1).YSize
+        no_data = gdal_ds.GetRasterBand(1).GetNoDataValue()
+
+        del gdal_ds
+        file_srs = osr.SpatialReference()
+        file_srs.ImportFromProj4(file_projection)
+
+        # margin 5km
+        margin_m = 5000
+
+        tile_polygon, tile_min_y, tile_max_y, tile_min_x, tile_max_x = \
+            self._get_tile_srs_bbox(
+                tile_min_y_utm - margin_m,
+                tile_max_y_utm + margin_m,
+                tile_min_x_utm - margin_m,
+                tile_max_x_utm + margin_m,
+                tile_srs, file_srs)
+
+        # if input does not requires reprojection due to
+        # antimeridian crossing
+        if not self._antimeridian_crossing_requires_special_handling(
+            file_srs, file_min_x, tile_min_x, tile_max_x):
+
+            # if it doesn't cross the antimeridian, reproject
+            # input file using gdalwarp
+            logger.info(f'    relocating file: {input_file} to'
+                        f' file: {relocated_file}')
+
+            gdal.Warp(relocated_file, input_file,
+                    format='GTiff',
+                    dstSRS=tile_srs_str,
+                    outputBounds=[tile_min_x_utm, tile_min_y_utm,
+                                    tile_max_x_utm, tile_max_y_utm],
+                    multithread=True,
+                    xRes=dx, yRes=abs(dy), resampleAlg=resample_algorithm,
+                    errorThreshold=0)
+
+            gdal_ds = gdal.Open(relocated_file, gdal.GA_ReadOnly)
+            relocated_array = gdal_ds.ReadAsArray()
+            del gdal_ds
+
+            return relocated_array
+
+        logger.info(f'    tile crosses the antimeridian')
+
+
+        file_max_x = file_min_x + file_width * file_dx
+        file_min_y = file_max_y + file_length * file_dy
+
+        # Crop input at the two sides of the antimeridian:
+        # left side: use tile bbox with file_max_x from input
+        proj_win_antimeridian_left = [tile_min_x,
+                                    tile_max_y,
+                                    file_max_x,
+                                    tile_min_y]
+
+        cropped_input_antimeridian_left_temp = tempfile.NamedTemporaryFile(
+                    dir=scratch_dir, suffix='.tif').name
+        logger.info(f'    cropping antimeridian-left side: {input_file} to'
+                    f' temporary file: {cropped_input_antimeridian_left_temp}'
+                    ' with indexes (ulx uly lrx lry):'
+                    f' {proj_win_antimeridian_left}')
+
+        gdal.Translate(cropped_input_antimeridian_left_temp, input_file,
+                    projWin=proj_win_antimeridian_left,
+                    outputSRS=file_srs,
+                    noData=no_data)
+
+        # right side: use tile bbox with file_min_x from input and tile_max_x
+        # with subtracted 360 (lon) degrees
+        proj_win_antimeridian_right = [file_min_x,
+                                    tile_max_y,
+                                    tile_max_x - 360,
+                                    tile_min_y]
+        cropped_input_antimeridian_right_temp = tempfile.NamedTemporaryFile(
+                    dir=scratch_dir, suffix='.tif').name
+
+        logger.info(f'    cropping antimeridian-right side: {input_file} to'
+                    f' temporary file: {cropped_input_antimeridian_right_temp}'
+                    ' with indexes (ulx uly lrx lry):'
+                    f' {proj_win_antimeridian_right}')
+
+        gdal.Translate(cropped_input_antimeridian_right_temp, input_file,
+                    projWin=proj_win_antimeridian_right,
+                    outputSRS=file_srs,
+                    noData=no_data)
+
+        if temp_files_list is not None:
+            temp_files_list.append(cropped_input_antimeridian_left_temp)
+            temp_files_list.append(cropped_input_antimeridian_right_temp)
+
+        gdalwarp_input_file_list = [cropped_input_antimeridian_left_temp,
+                                    cropped_input_antimeridian_right_temp]
+
+        logger.info(f'    relocating file: {input_file} to'
+                    f' file: {relocated_file}'
+                    f': {tile_min_x_utm} {tile_max_x_utm}'
+                    f': {tile_min_y_utm} {tile_max_y_utm}')
+        
+
+        gdal.Warp(relocated_file, gdalwarp_input_file_list,
+                format='GTiff',
+                dstSRS=tile_srs_str,
+                outputBounds=[tile_min_x_utm, tile_min_y_utm,
+                                tile_max_x_utm, tile_max_y_utm],
+                multithread=True,
+                xRes=dx, yRes=abs(dy), resampleAlg=resample_algorithm,
+                errorThreshold=0)
+
+        gdal_ds = gdal.Open(relocated_file, gdal.GA_ReadOnly)
+        relocated_array = gdal_ds.ReadAsArray()
+        del gdal_ds
+
+        return relocated_array
+
     def _read_x_y_array_geotiff(self, intput_tif_str):
         """Read X and Y coordinates from given Geotiff image
 
@@ -229,6 +527,66 @@ class AncillaryRelocation:
         del ds  # close the dataset (Python object and pointers)
 
         return ycoord, xcoord
+
+    def _antimeridian_crossing_requires_special_handling(
+            self, file_srs, file_min_x, tile_min_x, tile_max_x):
+        '''
+        Check if ancillary input requires special handling due to
+        the antimeridian crossing
+
+        Parameters
+        ----------
+        file_srs: osr.SpatialReference
+            Ancillary file spatial reference system (SRS)
+        file_min_x: float
+            Ancillary file min longitude value in degrees
+        tile_min_x: float
+            MGRS tile min longitude value in degrees
+        tile_max_x: float
+            MGRS tile max longitude value in degrees
+
+        Returns
+        -------
+        flag_requires_special_handling : bool
+            Flag that indicate if the ancillary input requires special handling
+        '''
+
+        # Flag to indicate if the if the MGRS tile crosses the antimeridian.
+        flag_tile_crosses_antimeridian = tile_min_x < 180 and tile_max_x >= 180
+
+        # Flag to test if the ancillary input file is in geographic
+        # coordinates and if its longitude domain is represented
+        # within the [-180, +180] range, rather than the [0, +360] interval.
+        # This is verified by the test `min_x < -170`. There's no specific reason
+        # why -170 is used. It could be -160, or even 0.
+        flag_input_geographic_and_longitude_not_0_360 = \
+            file_srs.IsGeographic() and file_min_x < -170
+
+        # If both are true, tile requires special handling due to the
+        # antimeridian crossing
+        flag_requires_special_handling = (
+            flag_tile_crosses_antimeridian and
+            flag_input_geographic_and_longitude_not_0_360)
+
+        return flag_requires_special_handling
+
+
+def get_projection_proj4(projection):
+    """Return projection in proj4 format
+
+       projection : str
+              Projection
+
+       Returns
+       -------
+       projection_proj4 : str
+              Projection in proj4 format
+    """
+    srs = osr.SpatialReference()
+    srs.ImportFromProj4(projection)
+    projection_proj4 = srs.ExportToProj4()
+    projection_proj4 = projection_proj4.strip()
+    return projection_proj4
 
 
 def replace_reference_water_nodata_from_ancillary(

--- a/src/dswx_sar/save_mgrs_tiles.py
+++ b/src/dswx_sar/save_mgrs_tiles.py
@@ -236,7 +236,7 @@ def find_intersecting_burst_with_bbox(ref_bbox,
             ref_polygon.overlaps(rtc_polygon):
                 overlapped_rtc_dir_list.append(input_dir)
         else:
-            print('fail to find the overlapped rtc')
+            logger.warning('fail to find the overlapped rtc')
             overlapped_rtc_dir_list = None
 
     return overlapped_rtc_dir_list
@@ -326,7 +326,8 @@ def crop_and_save_mgrs_tile(
 
 def get_intersecting_mgrs_tiles_list_from_db(
         image_tif,
-        mgrs_collection_file):
+        mgrs_collection_file,
+        track_number=None):
     """Find and return a list of MGRS tiles
     that intersect a reference GeoTIFF file
     By searching in database
@@ -337,6 +338,9 @@ def get_intersecting_mgrs_tiles_list_from_db(
         Path to the input GeoTIFF file.
     mgrs_collection_file : str
         Path to the MGRS tile collection.
+    track_number : int, optional
+        Track number (or relative orbit number) to specify 
+        MGRS tile collection
 
     Returns
     ----------
@@ -361,21 +365,47 @@ def get_intersecting_mgrs_tiles_list_from_db(
                                                 right,
                                                 top)
 
-    # Create a Polygon from the bounds
-    raster_polygon = Polygon(
-        [(left, bottom),
-         (left, top),
-         (right, top),
-         (right, bottom)])
-
+    antimeridian_crossing_flag = False
+    if left > 0  and right < 0:
+        antimeridian_crossing_flag = True
+        logger.info('The mosaic image crosses the antimeridian.')
     # Create a GeoDataFrame from the raster polygon
-    raster_gdf = gpd.GeoDataFrame([1],
-                                  geometry=[raster_polygon],
-                                  crs=4326)
+    if antimeridian_crossing_flag:
+        # Create a Polygon from the bounds
+        raster_polygon_left = Polygon(
+            [(left, bottom),
+            (left, top),
+            (180, top),
+            (180, bottom)])
+        raster_polygon_right = Polygon(
+            [(-180, bottom),
+            (-180, top),
+            (right, top),
+            (right, bottom)])
+        raster_gdf = gpd.GeoDataFrame([1, 2],
+                                      geometry=[raster_polygon_left,
+                                                raster_polygon_right],
+                                      crs=4326)
+    else:
+        # Create a Polygon from the bounds
+        raster_polygon = Polygon(
+            [(left, bottom),
+            (left, top),
+            (right, top),
+            (right, bottom)])
+        raster_gdf = gpd.GeoDataFrame([1],
+                                      geometry=[raster_polygon],
+                                      crs=4326)
 
     # Load the vector data
     vector_gdf = gpd.read_file(mgrs_collection_file)
-    vector_gdf = vector_gdf.to_crs("EPSG:4326")
+    
+    # If track number is given, then search MGRS tile collection with track number
+    if track_number is not None:
+        vector_gdf = vector_gdf[
+            vector_gdf['relative_orbit_number'] == track_number].to_crs("EPSG:4326")
+    else:
+        vector_gdf = vector_gdf.to_crs("EPSG:4326")
 
     # Calculate the intersection
     intersection = gpd.overlay(raster_gdf,
@@ -569,6 +599,7 @@ def run(cfg):
             tags = src.tags(0)
             date_str = tags['ZERO_DOPPLER_START_TIME']
             platform = tags['PLATFORM']
+            track_number = int(tags['TRACK_NUMBER'])
             resolution = src.transform[0]
             date_str_list.append(date_str)
 
@@ -745,7 +776,8 @@ def run(cfg):
     if database_bool:
         mgrs_tile_list, most_overlapped = get_intersecting_mgrs_tiles_list_from_db(
             mgrs_collection_file=mgrs_collection_db_path,
-            image_tif=paths['final_water'])
+            image_tif=paths['final_water'],
+            track_number=track_number)
         maximum_burst = most_overlapped['number_of_bursts']
         expected_burst_list = most_overlapped['bursts']
 


### PR DESCRIPTION
This PR fixes the bugs in the cases where the bursts are under the anti-meridian crossing. 
When testing with some cases (i.e., MS_1_59), the DEM got zero values only where the input DEM is geographic coordinates (EPSG4326). This is because the original code expects the input DEM to have the UTM coordinate, but the Copernicus DEM is the EPSG 4326. 
To be able to process even in the EPSG 4326 DEM, the PR replaced the old function (interpolate_gdal) with the modified one (_warp) .
This function came from DSWx-HLS after some modifications. : https://github.com/nasa/PROTEUS/blob/e5b411a91d5e78bc1479ba6d146ce62a29823e49/src/proteus/dswx_hls.py#L3185
