### PR TITLE
replace nodata values in reference water

### DIFF
--- a/src/dswx_sar/pre_processing.py
+++ b/src/dswx_sar/pre_processing.py
@@ -554,6 +554,11 @@ def replace_reference_water_nodata_from_ancillary(
             hand_block <= 0.002)
         ref_water_block[no_data_area | replaced_area] = reference_water_max
 
+        replaced_area = np.logical_and(
+            ref_water_block == reference_water_no_data,
+            landcover_block != landcover_label['Permanent water bodies'])
+        ref_water_block[replaced_area] = 0
+
         # write updated reference water 
         dswx_sar_util.write_raster_block(
             out_raster=reference_water_path,


### PR DESCRIPTION
This PR fixes the issues in the high-latitude regions. The Worldcover map covers up to 82 deg but reference water map  covers up to 78 deg. The uncovered areas from the ancillary data can cause high false positive rates. To address the issue, this PR updates the reference water map with the landcover map. 