### PR TITLE
automatic determination of polarizations and inundated vegetation

### DIFF
--- a/src/dswx_sar/defaults/algorithm_parameter_s1.yaml
+++ b/src/dswx_sar/defaults/algorithm_parameter_s1.yaml
@@ -8,7 +8,8 @@ runconfig:
         # [polarizations] for list of specific frequency(s) e.g. [VV, VH] or [VV]
         # 'dual-pol', 'co-pol', 'cross-pol' will search the polarizations Input GeoTiff files have. 
         # For example, 'co-pol' uses ['HH'], ['VV'], or ['HH', 'VV'] by looking at the input data. 
-        polarizations: ['dual-pol']
+        # ['auto'] will detect available polarizations from given RTC data
+        polarizations: ['auto']
         # Additional for polarimetric computations to be performed in specific polarization modes (co/cross and co + cross)
         # e.g. ['ratio', 'span'] 
         polarimetric_option:
@@ -164,7 +165,9 @@ runconfig:
                 surface_ratio: 0.1
 
         inundated_vegetation:
-            enabled: True
+            # 'auto' determine the inundated vegetation availability
+            # based on available cross-polarizations
+            enabled: auto
             dual_pol_ratio_max: 12
             dual_pol_ratio_min: 7
             dual_pol_ratio_threshold: 8

--- a/src/dswx_sar/detect_inundated_vegetation.py
+++ b/src/dswx_sar/detect_inundated_vegetation.py
@@ -5,7 +5,6 @@ import os
 import time
 
 import numpy as np
-import osgeo.gdal as gdal
 
 from dswx_sar import dswx_sar_util, filter_SAR, generate_log
 from dswx_sar.dswx_runconfig import DSWX_S1_POL_DICT, _get_parser, RunConfig
@@ -25,7 +24,7 @@ def run(cfg):
     outputdir = cfg.groups.product_path_group.scratch_path
     pol_list = copy.deepcopy(processing_cfg.polarizations)
     pol_options = processing_cfg.polarimetric_option
-    
+
     if pol_options is not None:
         pol_list += pol_options
 
@@ -53,7 +52,15 @@ def run(cfg):
        (('VV' in pol_list) and ('VH' in pol_list)):
         dual_pol_flag = True
 
-    if inundated_vege_cfg.enabled and not dual_pol_flag:
+    if inundated_vege_cfg.enabled == 'auto':
+        if dual_pol_flag:
+            inundated_vege_cfg_flag = True
+        else:
+            inundated_vege_cfg_flag = False
+    else:
+        inundated_vege_cfg_flag = inundated_vege_cfg.enabled
+
+    if inundated_vege_cfg_flag and not dual_pol_flag:
         err_str = 'Daul polarizations are required for inundated vegetation'
         raise ValueError(err_str)
 
@@ -128,7 +135,7 @@ def run(cfg):
         if processing_cfg.debug_mode:
             dswx_sar_util.write_raster_block(
                 out_raster=os.path.join(
-                outputdir, f'intensity_db_ratio_{pol_all_str}.tif'),
+                    outputdir, f'intensity_db_ratio_{pol_all_str}.tif'),
                 data=filt_ratio_db,
                 block_param=block_param,
                 geotransform=im_meta['geotransform'],

--- a/src/dswx_sar/dswx_runconfig.py
+++ b/src/dswx_sar/dswx_runconfig.py
@@ -20,15 +20,18 @@ WORKFLOW_SCRIPTS_DIR = os.path.dirname(dswx_sar.__file__)
 # Potential polarization scenarios for DSWx-S1
 # NOTE: DO NOT CHANGE THE ORDER of the items in the dictionary below.
 DSWX_S1_POL_DICT = {
-    'CO_POL' : ['HH', 'VV'],
-    'CROSS_POL' : ['HV', 'VH'],
-    'MIX_DUAL_POL' : ['HH', 'HV', 'VV', 'VH'],
-    'MIX_SINGLE_POL' : ['HH', 'VV'],
-    'DV_POL' : ['VV', 'VH'],
-    'SV_POL' : ['VV'],
-    'DH_POL' : ['HH', 'HV'],
-    'SH_POL' : ['HH'],
+    'CO_POL': ['HH', 'VV'],
+    'CROSS_POL': ['HV', 'VH'],
+    'MIX_DUAL_POL': ['HH', 'HV', 'VV', 'VH'],
+    'MIX_DUAL_H_SINGLE_V_POL': ['HH', 'HV', 'VV'],
+    'MIX_DUAL_V_SINGLE_H_POL': ['VV', 'VH', 'HH'],
+    'MIX_SINGLE_POL': ['HH', 'VV'],
+    'DV_POL': ['VV', 'VH'],
+    'SV_POL': ['VV'],
+    'DH_POL': ['HH', 'HV'],
+    'SH_POL': ['HH'],
     }
+
 
 def _get_parser():
     parser = argparse.ArgumentParser(description='',
@@ -50,6 +53,7 @@ def _get_parser():
                         help='Log file')
 
     return parser
+
 
 def _deep_update(original, update):
     """Update default runconfig dict with user-supplied dict.
@@ -76,6 +80,7 @@ def _deep_update(original, update):
 
     # return updated original
     return original
+
 
 def load_validate_yaml(yaml_path: str, workflow_name: str) -> dict:
     """Initialize RunConfig class with options from given yaml file.
@@ -163,6 +168,7 @@ def check_write_dir(dst_path: str):
         logger.error(err_str)
         raise PermissionError(err_str)
 
+
 def check_file_path(file_path: str) -> None:
     """Check if file_path exist else raise an error.
     Parameters
@@ -178,6 +184,7 @@ def check_file_path(file_path: str) -> None:
             err_str = f'{file_path} not found'
             logger.error(err_str)
             raise FileNotFoundError(err_str)
+
 
 def _find_polarization_from_data_dirs(input_dir_list):
     """
@@ -216,7 +223,7 @@ def _find_polarization_from_data_dirs(input_dir_list):
     if not extracted_strings:
         err_str = 'Failed to find polarizations from RTC files.'
         raise ValueError(err_str)
-        
+
     # return only unique polarizations
     return list(set(extracted_strings))
 
@@ -245,7 +252,7 @@ def check_polarizations(pol_list, input_dir_list):
     sorted_pol_list : list
         List of all polarizations sorted, prioritizing co-polarizations.
     """
-    if 'dual-pol' in pol_list:
+    if ('dual-pol' in pol_list) or ('auto' in pol_list):
         proc_pol_list = ['VV', 'VH', 'HH', 'HV']
     elif 'co-pol' in pol_list:
         proc_pol_list = ['VV', 'HH']
@@ -280,9 +287,9 @@ def check_polarizations(pol_list, input_dir_list):
         else:
             cross_pol_list.append(pol)
 
-    # Even though the first subset is found, the code should keep searching. 
+    # Even though the first subset is found, the code should keep searching.
     # For example, the ['VV', 'VH'] is a subset of `MIX_DUAL_POL` and `DV_POL`.
-    # The expected output is `DV_POL`. 
+    # The expected output is `DV_POL`.
     # So, the items in `DSWX_S1_POL_DICT` are sorted in an ordered manner.
     pol_mode = None
     for pol_mode_name, pols_in_mode in DSWX_S1_POL_DICT.items():
@@ -422,13 +429,15 @@ class RunConfig:
         debug_mode = processing_group.debug_mode
 
         if args.debug_mode and not debug_mode:
-            logger.warning(f'command line visualization "{args.debug_mode}"'
+            logger.warning(
+                f'command line visualization "{args.debug_mode}"'
                 f' has precedence over runconfig visualization "{debug_mode}"')
             sns.processing.debug_mode = args.debug_mode
 
         log_file = sns.log_file
         if args.log_file is not None:
-            logger.warning(f'command line log file "{args.log_file}"'
+            logger.warning(
+                f'command line log file "{args.log_file}"'
                 f' has precedence over runconfig log file "{log_file}"')
             sns.log_file = args.log_file
 

--- a/src/dswx_sar/dswx_s1.py
+++ b/src/dswx_sar/dswx_s1.py
@@ -19,6 +19,7 @@ from dswx_sar import generate_log
 
 logger = logging.getLogger('dswx_s1')
 
+
 def dswx_s1_workflow(cfg):
 
     t_all = time.time()
@@ -27,6 +28,7 @@ def dswx_s1_workflow(cfg):
     pol_mode = processing_cfg.polarization_mode
     input_list = cfg.groups.input_file_group.input_file_path
     dswx_workflow = processing_cfg.dswx_workflow
+    inundated_veg_cfg = processing_cfg.inundated_vegetation
 
     logger.info("")
     logger.info("Starting DSWx-S1 algorithm")
@@ -41,6 +43,12 @@ def dswx_s1_workflow(cfg):
                         DSWX_S1_POL_DICT['DH_POL']]
     elif pol_mode == 'MIX_SINGLE_POL':
         proc_pol_set = [DSWX_S1_POL_DICT['SV_POL'],
+                        DSWX_S1_POL_DICT['SH_POL']]
+    elif pol_mode == 'MIX_DUAL_H_SINGLE_V_POL':
+        proc_pol_set = [DSWX_S1_POL_DICT['DH_POL'],
+                        DSWX_S1_POL_DICT['SV_POL']]
+    elif pol_mode == 'MIX_DUAL_V_SINGLE_H_POL':
+        proc_pol_set = [DSWX_S1_POL_DICT['DV_POL'],
                         DSWX_S1_POL_DICT['SH_POL']]
     else:
         proc_pol_set = [pol_list]
@@ -66,7 +74,10 @@ def dswx_s1_workflow(cfg):
             # Refinement
             refine_with_bimodality.run(cfg)
 
-            if processing_cfg.inundated_vegetation.enabled:
+            if ((inundated_veg_cfg.enabled == 'auto') and
+               len(pol_set) >= 2) or \
+               inundated_veg_cfg.enabled is True:
+
                 detect_inundated_vegetation.run(cfg)
 
     processing_cfg.polarizations = pol_list
@@ -85,6 +96,7 @@ def main():
     generate_log.configure_log_file(cfg.groups.log_file)
 
     dswx_s1_workflow(cfg)
+
 
 if __name__ == '__main__':
     '''run dswx_s1 from command line'''

--- a/src/dswx_sar/initial_threshold.py
+++ b/src/dswx_sar/initial_threshold.py
@@ -865,12 +865,14 @@ def determine_threshold(
         # if estimated threshold is higher than bounds,
         # re-estimate threshold assuming tri-mode distribution
         if threshold > bounds[1] and mutli_threshold:
-            thresholds = threshold_multiotsu(intensity_sub)
+            try:
+                thresholds = threshold_multiotsu(intensity_sub)
 
-            if thresholds[0] < threshold:
-                threshold = thresholds[0]
-                idx_threshold = np.searchsorted(intensity_bins, threshold)
-
+                if thresholds[0] < threshold:
+                    threshold = thresholds[0]
+                    idx_threshold = np.searchsorted(intensity_bins, threshold)
+            except ValueError:
+                logger.info('Unable to find multi threshold')
         # Search the local peaks from histogram for initial values for fitting
         # peak for lower distribution
         lowmaxind_cands, _ = find_peaks(intensity_counts[0:idx_threshold+1], distance=5)

--- a/src/dswx_sar/refine_with_bimodality.py
+++ b/src/dswx_sar/refine_with_bimodality.py
@@ -67,73 +67,78 @@ class BimodalityMetrics:
         # remove invalid values
         mask = (np.isnan(int_db)) | (np.isinf(int_db)) | (np.isinf(-int_db))
         int_db = int_db[np.invert(mask)]
+        if len(int_db) >= 3:
+            self.enough_number = True
+            # Threshold for two Gaussian fitting
+            self.threshold_global_otsu = threshold_otsu(int_db)
 
-        # Threshold for two Gaussian fitting
-        self.threshold_global_otsu = threshold_otsu(int_db)
+            # If the threshold is too low,
+            # then apply multi-threshold algorithm
+            if self.threshold_global_otsu < gauss_dist_thres_bound[0]:
+                multithreshold_global_otsu = \
+                    threshold_multiotsu(int_db)
+                if any(multithreshold_global_otsu >=
+                       gauss_dist_thres_bound[0]):
+                    self.threshold_global_otsu_ind = \
+                        np.where((multithreshold_global_otsu >
+                                  gauss_dist_thres_bound[0]) &
+                                 (multithreshold_global_otsu <
+                                 gauss_dist_thres_bound[1]))
+                    self.threshold_global_otsu = \
+                        multithreshold_global_otsu[
+                            self.threshold_global_otsu_ind[0][0]]
 
-        # If the threshold is too low,
-        # then apply multi-threshold algorithm
-        if self.threshold_global_otsu < gauss_dist_thres_bound[0]:
-            multithreshold_global_otsu = threshold_multiotsu(int_db)
-            if any(multithreshold_global_otsu >= gauss_dist_thres_bound[0]):
-                self.threshold_global_otsu_ind = \
-                    np.where((multithreshold_global_otsu >
-                              gauss_dist_thres_bound[0]) &
-                             (multithreshold_global_otsu <
-                             gauss_dist_thres_bound[1]))
-                self.threshold_global_otsu = \
-                    multithreshold_global_otsu[
-                        self.threshold_global_otsu_ind[0][0]]
+            self.prob = self.counts * self.binstep
 
-        self.prob = self.counts * self.binstep
-
-        # Initial values for curve fitting using threshold computed above
-        left_sample = int_db[int_db < self.threshold_global_otsu]
-        right_sample = int_db[int_db > self.threshold_global_otsu]
-        if len(left_sample)>0 and len(right_sample)>0:
-            mean_lt = np.nanmean(left_sample)
-            mean_gt= np.nanmean(right_sample)
-            std_lt = np.std(left_sample)
-            std_gt = np.std(right_sample)
-        else:
-            mean_lt = self.threshold_global_otsu - 1
-            mean_gt = self.threshold_global_otsu + 1
-            std_lt, std_gt = 1, 1
-
-        amp_lt_ind = np.abs(self.bincenter - mean_lt).argmin()
-        amp_lt = self.prob[amp_lt_ind]
-        amp_gt_ind = np.abs(self.bincenter - mean_gt).argmin()
-        amp_gt = self.prob[amp_gt_ind]
-
-        try:
-            # starting value for curve_fit
-            # mean, std, amplitude, mean, std, amplitude
-            expected = (mean_lt, std_lt, amp_lt,
-                        mean_gt, std_gt, amp_gt)
-            params, _ = curve_fit(self.bimodal,
-                                  self.bincenter,
-                                  self.prob,
-                                  expected,
-                                  bounds=(
-                                    (-30, 1e-10, 0,
-                                    -30, 1e-10, 0),
-                                    (5, 5, 1,
-                                     5, 5, 1)))
-            if params[0] > params[3]:
-                self.second_mode = params[:3]
-                self.first_mode = params[3:]
+            # Initial values for curve fitting using threshold computed above
+            left_sample = int_db[int_db < self.threshold_global_otsu]
+            right_sample = int_db[int_db > self.threshold_global_otsu]
+            if len(left_sample) > 0 and len(right_sample) > 0:
+                mean_lt = np.nanmean(left_sample)
+                mean_gt = np.nanmean(right_sample)
+                std_lt = np.std(left_sample)
+                std_gt = np.std(right_sample)
             else:
-                self.first_mode = params[:3]
-                self.second_mode = params[3:]
-            # Left Gaussian
-            self.simul_first = self.gauss(self.bincenter, *self.first_mode)
-            self.simul_second = self.gauss(self.bincenter, *self.second_mode)
-            self.simul_all = self.simul_first + self.simul_second
-            self.optimization = True
-        except:
-            logger.info(f'Bimodal curve Fitting fails in BimodalityMetrics.')
-            self.optimization = False
+                mean_lt = self.threshold_global_otsu - 1
+                mean_gt = self.threshold_global_otsu + 1
+                std_lt, std_gt = 1, 1
 
+            amp_lt_ind = np.abs(self.bincenter - mean_lt).argmin()
+            amp_lt = self.prob[amp_lt_ind]
+            amp_gt_ind = np.abs(self.bincenter - mean_gt).argmin()
+            amp_gt = self.prob[amp_gt_ind]
+
+            try:
+                # starting value for curve_fit
+                # mean, std, amplitude, mean, std, amplitude
+                expected = (mean_lt, std_lt, amp_lt,
+                            mean_gt, std_gt, amp_gt)
+                params, _ = curve_fit(self.bimodal,
+                                      self.bincenter,
+                                      self.prob,
+                                      expected,
+                                      bounds=(
+                                        (-30, 1e-10, 0,
+                                         -30, 1e-10, 0),
+                                        (5, 5, 1,
+                                         5, 5, 1)))
+                if params[0] > params[3]:
+                    self.second_mode = params[:3]
+                    self.first_mode = params[3:]
+                else:
+                    self.first_mode = params[:3]
+                    self.second_mode = params[3:]
+                # Left Gaussian
+                self.simul_first = self.gauss(self.bincenter, *self.first_mode)
+                self.simul_second = self.gauss(self.bincenter, *self.second_mode)
+                self.simul_all = self.simul_first + self.simul_second
+                self.optimization = True
+            except:
+                logger.info('Bimodal curve Fitting fails in BimodalityMetrics.')
+                self.optimization = False
+        else:
+            self.optimization = False
+            self.enough_number = False
 
     def gauss(self, array, mu, sigma, amplitude):
         """ Calculate the value of a Gaussian (normal) function.
@@ -358,47 +363,50 @@ class BimodalityMetrics:
         ashman, bhc, surface_ratio, bm_coeff, bc_coeff = \
             (None, None, None, None, None)
         bimodality_flag = False
+        if self.enough_number:
+            if self.optimization and len(self.int_db) > 4:
+                (ashman, bhc, surface_ratio,
+                 bm_coeff, bc_coeff) = self.get_metric()
 
-        if self.optimization and len(self.int_db) > 4:
-            ashman, bhc, surface_ratio, bm_coeff, bc_coeff = self.get_metric()
+                # Check if the data satisfies the conditions for bimodality
+                bm_coeff_bool = bm_flag and \
+                    (bm_coeff is None or bm_coeff > thresholds[3])
+                ashman_bool = ashman_flag and \
+                    (ashman is None or ashman > thresholds[0])
+                bhc_bool = bhc_flag and \
+                    (bhc is None or bhc > thresholds[1])
+                surface_ratio_bool = surface_ratio_flag and \
+                    (surface_ratio is None or surface_ratio > thresholds[2])
+                bc_coeff_bool = bc_flag and \
+                    (bc_coeff is None or bc_coeff > 5/9)
+                bimodal_metrics = (int(ashman_bool) +
+                                   int(bm_coeff_bool) +
+                                   int(bc_coeff_bool))
+                # If more than two metric satisficed are higher than threshold
+                # or ashman coefficient is higher than 3
+                # and surface ratio is higher than threshold
+                bool_set = [(bimodal_metrics >= 2) or
+                            (ashman > 3),
+                            surface_ratio_bool]
 
-            # Check if the data satisfies the conditions for bimodality
-            bm_coeff_bool = bm_flag and \
-                (bm_coeff is None or bm_coeff > thresholds[3])
-            ashman_bool = ashman_flag and \
-                (ashman is None or ashman > thresholds[0])
-            bhc_bool = bhc_flag and \
-                (bhc is None or bhc > thresholds[1])
-            surface_ratio_bool = surface_ratio_flag and \
-                (surface_ratio is None or surface_ratio > thresholds[2])
-            bc_coeff_bool = bc_flag and \
-                (bc_coeff is None or bc_coeff > 5/9)
-            bimodal_metrics = (int(ashman_bool) +
-                               int(bm_coeff_bool) +
-                               int(bc_coeff_bool))
-            # If more than two metric satisficed are higher than threshold
-            # or ashman coefficient is higher than 3
-            # and surface ratio is higher than threshold
-            bool_set = [ (bimodal_metrics >=2) or (ashman > 3) , surface_ratio_bool]
-
-            if all(element for element in bool_set):
-                bimodality_flag = True
-        else:
-            # If optimization fails, then apply alternative way
-            # Compute bimodality using the estimate_bimodality function
-            bt_max, ad_max = estimate_bimodality(self.int_db)
-            if (bt_max > thresholds[3]) & (ad_max > 1.5):
-                bimodality_flag = True
+                if all(element for element in bool_set):
+                    bimodality_flag = True
+            else:
+                # If optimization fails, then apply alternative way
+                # Compute bimodality using the estimate_bimodality function
+                bt_max, ad_max = estimate_bimodality(self.int_db)
+                if (bt_max > thresholds[3]) & (ad_max > 1.5):
+                    bimodality_flag = True
 
         return bimodality_flag
-
 
     def get_metric(self):
         """
         Calculate bimodality metrics based on the optimization flag.
 
         Returns:
-            list: A list containing bimodality metrics. The list has the following elements:
+            list: A list containing bimodality metrics.
+            The list has the following elements:
                 - ashman (float): The Ashman coefficient.
                 - bhc (float): The Bhattacharyya coefficient.
                 - surface_ratio (float): The surface ratio.
@@ -490,7 +498,7 @@ def estimate_bimodality(array,
                         / left_sum
                     stdp_left = np.sqrt(np.nansum(
                         ((counts_smooth[cand_left] * bincenter[cand_left])
-                        - meanp_left )**2)) / left_sum
+                         - meanp_left)**2)) / left_sum
                     probp_left = np.nansum(counts_smooth[cand_left]) / countsum
 
                 else:
@@ -502,7 +510,7 @@ def estimate_bimodality(array,
                         / right_sum
                     stdp_right = np.sqrt(np.nansum(
                         ((counts_smooth[cand_right] * bincenter[cand_right])
-                        - meanp_right )**2)) / right_sum
+                         - meanp_right)**2)) / right_sum
                     probp_right = np.nansum(counts_smooth[cand_right]) / countsum
                 else:
                     meanp_right, stdp_right, probp_right = 0, 0, 0
@@ -987,7 +995,7 @@ def remove_false_water_bimodality_parallel(water_mask_path,
                                 scratch_dir=outputdir)
 
             if {'HH', 'HV', 'VV', 'VH'}.intersection(set(pol_list)):
-                bimodality_total = np.squeeze(np.nansum(bimodality_set, axis=0))
+                bimodality_total = np.nansum(bimodality_set, axis=0)
                 # 0 value in output_water indicates the non-water
                 bimodality_total[output_water==0] = False
             else:

--- a/src/dswx_sar/schemas/algorithm_parameter_s1.yaml
+++ b/src/dswx_sar/schemas/algorithm_parameter_s1.yaml
@@ -162,7 +162,9 @@ runconfig:
                 surface_ratio: num(min=0, required=False)
 
         inundated_vegetation:
-            enabled: bool(required=False)
+            # 'auto' determine the inundated vegetation availability
+            # based on available cross-polarizations
+            enabled: enum(True, False, 'auto')
             dual_pol_ratio_max: num(min=0, max=30, required=False)
             dual_pol_ratio_min: num(min=0, max=30, required=False)
             dual_pol_ratio_threshold: num(min=0, max=30, required=False)


### PR DESCRIPTION
This PR adds new options for polarizations and inundated vegetation. 

In strategies using MGRS tile collection database, multiple scenarios could happen as follows:

1. all bursts have dual polarizations
   1.1. all bursts have the same polarizations  (e.g., VV/VH) 
   1.2. some bursts have dual VV/VH polarization, but the others have HH/HV polarizations. 
2. all bursts have single polarizations (e.g., VV)
    2.1. all bursts have the same polarizations  (e.g., VV) 
    2.2. some bursts have single VV polarization, but the others have HH polarizations. 
3. some bursts have dual (e.g., VV/VH) but the others have single polarizations
    3.1. all bursts have the same polarizations  (e.g., VV/VH and VV) 
    3.2. some bursts have dual VV/VH polarization, but the others have HH polarizations. 

To handle all possible scenarios, this PR adds more polarimetric cases. New code automatically searches the available polarizations from the given RTC bursts.

Depending on the availability of cross-polarization, the inundated vegetation will be enabled/disabled. For example, the inundated vegetation mapping is possible in scenario 1) and 3). In particular, in scenario 3, only limited areas have inundated vegetation. 