### PR TITLE
Add polarization mode to metadata

### DIFF
--- a/src/dswx_sar/dswx_runconfig.py
+++ b/src/dswx_sar/dswx_runconfig.py
@@ -19,6 +19,10 @@ WORKFLOW_SCRIPTS_DIR = os.path.dirname(dswx_sar.__file__)
 
 # Potential polarization scenarios for DSWx-S1
 # NOTE: DO NOT CHANGE THE ORDER of the items in the dictionary below.
+# There are more modes such as 'MIX_DUAL_V_SINGLE_V' and 
+# 'MIX_DUAL_H_SINGLE_H' describing the dual_polarization and
+# single polarization with same polarization. This mode will be 
+# deteremine by counting the available bursts. 
 DSWX_S1_POL_DICT = {
     'CO_POL': ['HH', 'VV'],
     'CROSS_POL': ['HV', 'VH'],

--- a/src/dswx_sar/save_mgrs_tiles.py
+++ b/src/dswx_sar/save_mgrs_tiles.py
@@ -651,13 +651,28 @@ def run(cfg):
             pol_type2 = 'SH_POL'
         else:
             logger.info('There is no need to mosaic different polarizations.')
-        pol_set1 = DSWX_S1_POL_DICT[pol_type1]
-        pol_set2 = DSWX_S1_POL_DICT[pol_type2]
-        merge_pol_list = ['_'.join(pol_set1),
-                          '_'.join(pol_set2)]
+            merge_layer_flag = False
+        if merge_layer_flag:
+            pol_set1 = DSWX_S1_POL_DICT[pol_type1]
+            pol_set2 = DSWX_S1_POL_DICT[pol_type2]
+            merge_pol_list = ['_'.join(pol_set1),
+                              '_'.join(pol_set2)]
     else:
         pol_set1 = pol_list
         pol_set2 = []
+        count_pols = [len(glob.glob(f'{input_dir}/*{pol_candidate}*.tif'))
+                      for pol_candidate in pol_list]
+
+        # count_pols is list of number of the available pols.
+        # count_pols[0] is always copol because
+        # Co-pol proceed before cross-pol.
+        if len(pol_list) > 1 and np.any(count_pols != count_pols[0]):
+            # get first character from polarization (V or H)
+            pol_id = pol_list[0][0]
+            pol_mode = f'MIX_DUAL_{pol_id}_SINGLE_{pol_id}_POL'
+
+    logger.info(f'Products are made from {pol_mode} scenario.')
+
     # If polarimetric methods such as ratio, span are used,
     # it is added to the name.
     if pol_options is not None and merge_layer_flag:
@@ -897,7 +912,7 @@ def run(cfg):
                                  set(actual_burst_id)))
         mgrs_meta_dict['MGRS_COLLECTION_MISSING_NUMBER_OF_BURSTS'] = \
             missing_burst
-
+        mgrs_meta_dict['MGRS_POL_MODE'] = pol_mode
     else:
         mgrs_tile_list = get_intersecting_mgrs_tiles_list(
             image_tif=paths['final_water'])


### PR DESCRIPTION
This PR adds the `pol_mode` to metadata field to better understand how the product is generated. 
There are cases such as 
    'MIX_DUAL_POL': ['HH', 'HV', 'VV', 'VH'],
    'MIX_DUAL_H_SINGLE_V_POL': ['HH', 'HV', 'VV'],
    'MIX_DUAL_V_SINGLE_H_POL': ['VV', 'VH', 'HH'],
    'MIX_SINGLE_POL': ['HH', 'VV'],
    'DV_POL': ['VV', 'VH'],
    'SV_POL': ['VV'],
    'DH_POL': ['HH', 'HV'],
    'SH_POL': ['HH'],
    'MIX_DUAL_V_DUAL_V_POL' : ['VV', 'VH', 'VV'], 
    'MIX_DUAL_H_DUAL_H_POL' : ['HH', 'HV', 'HH'], 
