### PR TITLE
change default value for browse image and save browse image to output

### DIFF
--- a/src/dswx_sar/defaults/dswx_s1.yaml
+++ b/src/dswx_sar/defaults/dswx_s1.yaml
@@ -104,12 +104,15 @@ runconfig:
             set_not_water_to_nodata: False
 
             # Flag to set HAND mask pixels to NoData value if set to True. 
-            set_hand_mask_to_nodata: False
+            set_hand_mask_to_nodata: True
 
             # Flag to set layover and shadow pixels to NoData value if set to True. 
-            set_layover_shadow_to_nodata: False
+            set_layover_shadow_to_nodata: True
             
             # Flag to set ocean-masked pixels to NoData value if set to True. 
             set_ocean_masked_to_nodata: False
+
+            # Flag to save Geotiff to output directory if set to True. 
+            save_tif_to_output: True
 
         log_file: None

--- a/src/dswx_sar/dswx_sar_util.py
+++ b/src/dswx_sar/dswx_sar_util.py
@@ -1554,7 +1554,8 @@ def create_browse_image(water_geotiff_filename,
                         set_not_water_to_nodata=False,
                         set_hand_mask_to_nodata=False,
                         set_layover_shadow_to_nodata=False,
-                        set_ocean_masked_to_nodata=False):
+                        set_ocean_masked_to_nodata=False,
+                        save_tif_to_output_dir=False):
     """
     Process a water-related GeoTIFF file to create a browse image.
 
@@ -1594,6 +1595,8 @@ def create_browse_image(water_geotiff_filename,
         If True, sets layover and shadow pixels to NoData. Default is False.
     set_ocean_masked_to_nodata : bool, optional
         If True, sets ocean-masked pixels to NoData. Default is False.
+    save_tif_to_output_dir : bool, optional
+        If True, save browse GeoTIff to output directory.
 
     Returns
     --------
@@ -1619,10 +1622,12 @@ def create_browse_image(water_geotiff_filename,
 
     # Form color table
     browse_ctable = get_interpreted_dswx_s1_ctable()
-    water_geotiff_basename = \
-        os.path.splitext(os.path.basename(water_geotiff_filename))[0]
-    browse_image_geotiff_filename = os.path.join(
-        scratch_dir, f'{water_geotiff_basename}_browse.tif')
+    if save_tif_to_output_dir:
+        browse_image_geotiff_filename = os.path.join(
+            output_dir_path, f'{browser_filename}.tif')
+    else:
+        browse_image_geotiff_filename = os.path.join(
+            scratch_dir, f'{browser_filename}.tif')
 
     _save_array(
         input_array=browse_arr,
@@ -1639,7 +1644,7 @@ def create_browse_image(water_geotiff_filename,
     geotiff2png(
         src_geotiff_filename=browse_image_geotiff_filename,
         dest_png_filename=os.path.join(output_dir_path,
-                                       browser_filename),
+                                       f'{browser_filename}.png'),
         output_height=browse_image_height,
         output_width=browse_image_width,
         logger=logger

--- a/src/dswx_sar/save_mgrs_tiles.py
+++ b/src/dswx_sar/save_mgrs_tiles.py
@@ -578,6 +578,7 @@ def run(cfg):
     set_layover_shadow_to_nodata = \
         browser_image_cfg.set_layover_shadow_to_nodata
     set_ocean_masked_to_nodata = browser_image_cfg.set_ocean_masked_to_nodata
+    save_tif_to_output = browser_image_cfg.save_tif_to_output
 
     shapefile = cfg.groups.dynamic_ancillary_file_group.shoreline_shapefile
     ocean_mask_enabled = processing_cfg.ocean_mask.mask_enabled
@@ -964,7 +965,7 @@ def run(cfg):
                 output_mgrs_bwtr = f'{dswx_name_format_prefix}_B02_BWTR.tif'
                 output_mgrs_conf = f'{dswx_name_format_prefix}_B03_CONF.tif'
                 output_mgrs_diag = f'{dswx_name_format_prefix}_B04_DIAG.tif'
-                output_mgrs_browse = f'{dswx_name_format_prefix}_BROWSE.png'
+                output_mgrs_browse = f'{dswx_name_format_prefix}_BROWSE'
 
                 # Crop full size of BWTR, WTR, CONF file
                 # and save them into MGRS tile grid
@@ -1007,7 +1008,8 @@ def run(cfg):
                         set_not_water_to_nodata=set_not_water_to_nodata,
                         set_hand_mask_to_nodata=set_hand_mask_to_nodata,
                         set_layover_shadow_to_nodata=set_layover_shadow_to_nodata,
-                        set_ocean_masked_to_nodata=set_ocean_masked_to_nodata)
+                        set_ocean_masked_to_nodata=set_ocean_masked_to_nodata,
+                        save_tif_to_output_dir=save_tif_to_output)
 
     t_all_elapsed = time.time() - t_all
     logger.info("successfully ran save_mgrs_tiles in "

--- a/src/dswx_sar/schemas/dswx_s1.yaml
+++ b/src/dswx_sar/schemas/dswx_s1.yaml
@@ -96,21 +96,24 @@ runconfig:
             browse_image_width: int(min=1, required=False)
 
             # Flag to collapse water classes if set to True. Default is True.
-            flag_collapse_wtr_classes:  bool(required=False)
+            flag_collapse_wtr_classes: bool(required=False)
 
             # Flag to exclude inundated vegetation from processing if set to True. 
-            exclude_inundated_vegetation:  bool(required=False)
+            exclude_inundated_vegetation: bool(required=False)
 
             # Flag to set non-water pixels to NoData value if set to True. 
-            set_not_water_to_nodata:  bool(required=False)
+            set_not_water_to_nodata: bool(required=False)
 
             # Flag to set HAND mask pixels to NoData value if set to True. 
-            set_hand_mask_to_nodata:  bool(required=False)
+            set_hand_mask_to_nodata: bool(required=False)
 
             # Flag to set layover and shadow pixels to NoData value if set to True. 
-            set_layover_shadow_to_nodata:  bool(required=False)
+            set_layover_shadow_to_nodata: bool(required=False)
             
             # Flag to set ocean-masked pixels to NoData value if set to True. 
-            set_ocean_masked_to_nodata:  bool(required=False)
+            set_ocean_masked_to_nodata: bool(required=False)
+
+            # Flag to save Geotiff to output directory if set to True. 
+            save_tif_to_output: bool(required=False)
 
         log_file: str(required=False)


### PR DESCRIPTION
This PR addresses the recent request from PST. 

The changes are below. 

1. Changes the default value for browse images to make HAND and layover/shadow mask transparent. 
2. Adds the option to save the browse geotiff to the SAS output directory. 