### PR TITLE
Fix bugs/issues in calval point (0.4.1)

### DIFF
--- a/src/dswx_sar/dswx_sar_util.py
+++ b/src/dswx_sar/dswx_sar_util.py
@@ -890,7 +890,7 @@ def write_raster_block(out_raster, data,
     number_band = 1 if ndim < 3 else data.shape[0]
 
     data_start_without_pad = block_param.write_start_line - \
-        block_param.read_start_line
+        block_param.read_start_line + block_param.block_pad[0][0]
     data_end_without_pad = data_start_without_pad + \
         block_param.block_length
 

--- a/src/dswx_sar/dswx_sar_util.py
+++ b/src/dswx_sar/dswx_sar_util.py
@@ -252,8 +252,11 @@ def save_dswx_product(wtr, output_file, geotransform,
         print(msg)
 
     band_value_dict = band_assign_value_dict
+    sorted_band_keys = sorted(
+        band_value_dict.keys(),
+        key=lambda x: x.lower() == 'inundated_vegetation')
 
-    for band_key in band_value_dict.keys():
+    for band_key in sorted_band_keys:
         if band_key.lower() in dswx_processed_bands_keys:
             dswx_product_value = band_value_dict[band_key]
             wtr[dswx_processed_bands[band_key.lower()] == 1] = \

--- a/src/dswx_sar/metadata.py
+++ b/src/dswx_sar/metadata.py
@@ -308,7 +308,7 @@ def compute_layover_shadow_coverage(data_array):
 
     if valid_pixels > 0:
         return round(layover_shadow_pixels /
-                     valid_pixels, 4)
+                     valid_pixels * 100, 4)
     else:
         return 0
 

--- a/src/dswx_sar/metadata.py
+++ b/src/dswx_sar/metadata.py
@@ -291,8 +291,6 @@ def compute_layover_shadow_coverage(data_array):
     ----------
     data_array : np.array
         The 2D numpy array representation of the GeoTIFF.
-    spatial_coverage : float
-        Spatial coverage as a percentage.
 
     Returns
     -------
@@ -310,7 +308,7 @@ def compute_layover_shadow_coverage(data_array):
         return round(layover_shadow_pixels /
                      valid_pixels * 100, 4)
     else:
-        return 0
+        return 0.0
 
 
 def _populate_statics_metadata_datasets(dswx_metadata_dict, dswx_geotiff):

--- a/src/dswx_sar/metadata.py
+++ b/src/dswx_sar/metadata.py
@@ -283,7 +283,7 @@ def compute_spatial_coverage(data_array):
     return round(valid_pixels / total_pixels * 100, 4)
 
 
-def compute_layover_shadow_coverage(data_array, spatial_coverage):
+def compute_layover_shadow_coverage(data_array):
     """
     Compute the layover-shadow coverage.
 
@@ -301,12 +301,16 @@ def compute_layover_shadow_coverage(data_array, spatial_coverage):
     """
     layover_shadow_pixels = np.sum(
         data_array == band_assign_value_dict['layover_shadow_mask'])
+    total_pixels = data_array.size
+    invalid_pixels = np.sum(
+        data_array == band_assign_value_dict['no_data'])
+    valid_pixels = total_pixels - invalid_pixels
 
-    if spatial_coverage > 0:
+    if valid_pixels > 0:
         return round(layover_shadow_pixels /
-                     (spatial_coverage * data_array.size), 4)
+                     valid_pixels, 4)
     else:
-        return np.nan
+        return 0
 
 
 def _populate_statics_metadata_datasets(dswx_metadata_dict, dswx_geotiff):
@@ -326,7 +330,7 @@ def _populate_statics_metadata_datasets(dswx_metadata_dict, dswx_geotiff):
 
         spatial_cov = compute_spatial_coverage(dswx_data)
         layover_shadow_cov = compute_layover_shadow_coverage(
-            dswx_data, spatial_cov)
+            dswx_data)
 
         dswx_metadata_dict['SPATIAL_COVERAGE'] = spatial_cov
         dswx_metadata_dict['LAYOVER_SHADOW_COVERAGE'] = layover_shadow_cov

--- a/src/dswx_sar/refine_with_bimodality.py
+++ b/src/dswx_sar/refine_with_bimodality.py
@@ -909,7 +909,7 @@ def remove_false_water_bimodality_parallel(water_mask_path,
 
             # save the water label into file
             water_label_str = os.path.join(
-                outputdir, f'false_water_label_{pol_str}.tif')
+                outputdir, f'false_water_label_{pol_str}_{block_iter}.tif')
             dswx_sar_util.write_raster_block(
                 water_label_str,
                 output_water,
@@ -1034,7 +1034,9 @@ def remove_false_water_bimodality_parallel(water_mask_path,
                         ref_land_portion_image = ref_land_portion_output[
                             index_array_to_image]
                         dswx_sar_util.write_raster_block(
-                            os.path.join(outputdir, f'land_portion_{pol}.tif'),
+                            os.path.join(
+                                outputdir,
+                                f'land_portion_{pol}_{block_iter}.tif'),
                             ref_land_portion_image,
                             block_param,
                             geotransform=meta_info['geotransform'],
@@ -1044,11 +1046,11 @@ def remove_false_water_bimodality_parallel(water_mask_path,
                             scratch_dir=outputdir)
 
                         metric_detail_name = [
-                            f'binary_ahman_{pol}.tif',
-                            f'binary_bhc_{pol}.tif',
-                            f'binary_asurface_ratio_{pol}.tif',
-                            f'binary_bm_coeff_{pol}.tif',
-                            f'binary_bc_coeff_{pol}.tif']
+                            f'binary_ahman_{pol}_{block_iter}.tif',
+                            f'binary_bhc_{pol}_{block_iter}.tif',
+                            f'binary_asurface_ratio_{pol}_{block_iter}.tif',
+                            f'binary_bm_coeff_{pol}_{block_iter}.tif',
+                            f'binary_bc_coeff_{pol}_{block_iter}.tif']
 
                         metric_output = np.insert(metric_output,
                                                   0,
@@ -1498,7 +1500,7 @@ def run(cfg):
         merged_layer_path=bright_water_path,
         lines_per_block=lines_per_block,
         mode='or', cog_flag=True,
-        scratch_dir='.')
+        scratch_dir=outputdir)
 
     fill_gap_bindary_path = \
         fill_gap_water_bimodality_parallel(
@@ -1521,7 +1523,7 @@ def run(cfg):
         lines_per_block=lines_per_block,
         mode='or',
         cog_flag=True,
-        scratch_dir='.')
+        scratch_dir=outputdir)
 
     t_time_end = time.time()
     t_all_elapsed = t_time_end - t_all

--- a/src/dswx_sar/save_mgrs_tiles.py
+++ b/src/dswx_sar/save_mgrs_tiles.py
@@ -661,13 +661,25 @@ def run(cfg):
     else:
         pol_set1 = pol_list
         pol_set2 = []
-        count_pols = [len(glob.glob(f'{input_dir}/*{pol_candidate}*.tif'))
-                      for pol_candidate in pol_list]
+        count_pols = []
+        for input_dir in input_list:
+            pol_types = DSWX_S1_POL_DICT['DV_POL'] + \
+                        DSWX_S1_POL_DICT['DH_POL']
+            # Initialize count
+            count_pol = 0
+            # Count files for each polarization type
+            for target_pol in pol_types:
+                pol_files = glob.glob(
+                    os.path.join(input_dir, f'*{target_pol}*.tif'))
+                count_pol += len(pol_files)
+            count_pols.append(count_pol)
+        all_match_first = all(count == count_pols[0]
+                              for count in count_pols)
 
         # count_pols is list of number of the available pols.
         # count_pols[0] is always copol because
         # Co-pol proceed before cross-pol.
-        if len(pol_list) > 1 and np.any(count_pols != count_pols[0]):
+        if len(pol_list) > 1 and not all_match_first:
             # get first character from polarization (V or H)
             pol_id = pol_list[0][0]
             pol_mode = f'MIX_DUAL_{pol_id}_SINGLE_{pol_id}_POL'

--- a/src/dswx_sar/schemas/dswx_s1.yaml
+++ b/src/dswx_sar/schemas/dswx_s1.yaml
@@ -69,7 +69,7 @@ runconfig:
             # according to proper file naming conventions.
             sas_output_path: str()
 
-            product_version: num(required=False)
+            product_version: str(required=False)
 
             # DSWx-S1 product format (default is 'COG')
             output_imagery_format: enum('GTiff', 'COG', required=False)


### PR DESCRIPTION
This PR addresses bugs and minor updates:

1. `dswx_sar_util.py`: Previously, when saving the CONF products, the dark land (represented by red color in the product) was overriding the inundated vegetation. We have modified it so that the inundated vegetation takes precedence over the dark land.

2. `metadata.py`: In previous versions, the layover/shadow coverage sometimes resulted in NaN values. The spatial coverage, calculated as `valid pixels / entire pixels * 100`, was used as an input. However, this value could be 0 in cases where there were a small number of pixels in the MGRS tile due to the expression using four floating-point numbers. Instead of using the spatial coverage percentage, we now compute the number of valid pixels and calculate the layover/shadow coverage using layover_shadow / valid_pixels.

3. `refine_with_bimodality.py`: Intermediate files generated in debug mode are now renamed to include the iteration. Also, the some of intermediate files was saved in the `'.'`. So this changed to the scratch directory. 

4. `dswx_s1.yaml`: The product version has been changed from a number to a string, as requested by SDS.

5. `save_mgrs_tile.py`: The pol_mode field saved in the metadata has been modified.