### PR TITLE
Add GLAD product as ancillary input for inundated vegetation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -67,3 +67,34 @@ docker load -i docker/dockerimg_dswx_s1_calval_0.4.1.tar
 ```
 
 See DSWx-SAR Science Algorithm Software (SAS) User Guide for instructions on processing via Docker.
+
+
+### License
+**Copyright (c) 2021** California Institute of Technology (“Caltech”). U.S. Government
+sponsorship acknowledged.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided
+that the following conditions are met:
+* Redistributions of source code must retain the above copyright notice, this list of conditions and
+the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+and the following disclaimer in the documentation and/or other materials provided with the
+distribution.
+* Neither the name of Caltech nor its operating division, the Jet Propulsion Laboratory, nor the
+names of its contributors may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/src/dswx_sar/defaults/algorithm_parameter_ni.yaml
+++ b/src/dswx_sar/defaults/algorithm_parameter_ni.yaml
@@ -14,7 +14,7 @@ runconfig:
         # e.g. ['ratio', 'span'] 
         polarimetric_option:
 
-        # Specifiy the max_value for permanent water and no_data_value for invalid pixels
+        # Specify the max_value for permanent water and no_data_value for invalid pixels
         reference_water:
             max_value: 100
             no_data_value: 255

--- a/src/dswx_sar/defaults/algorithm_parameter_s1.yaml
+++ b/src/dswx_sar/defaults/algorithm_parameter_s1.yaml
@@ -209,7 +209,7 @@ runconfig:
             cross_pol_min: -26
             line_per_block: 300
             target_area_file_type: 'auto'
-            target_worldcover_land_cover: ['Herbaceous wetland']
+            target_worldcover_class: ['Herbaceous wetland']
             target_glad_class: ['112-124', '200-207', '19-24', '125-148']
             filter:
                 enabled: True

--- a/src/dswx_sar/defaults/algorithm_parameter_s1.yaml
+++ b/src/dswx_sar/defaults/algorithm_parameter_s1.yaml
@@ -14,7 +14,7 @@ runconfig:
         # e.g. ['ratio', 'span']
         polarimetric_option:
 
-        # Specifiy the max_value for permanent water and no_data_value for invalid pixels
+        # Specify the max_value for permanent water and no_data_value for invalid pixels
         reference_water:
             max_value: 100
             no_data_value: 255
@@ -54,11 +54,19 @@ runconfig:
                 window_size: 3
             guided_filter:
                 radius: 1
+                # Regularization parameter in Guided Filter to smooth within
+                # a radius. Default is 3.
                 eps: 3
+                # The depth of the output image.
                 ddepth: -1
             bregman:
+                # The regularization parameter for TV Bregman denoising.
+                # It controls the amount of smoothing. Higher values
+                # produce more smoothed results.
                 lambda_value: 20
             anisotropic_diffusion:
+                # Denoising weight. The greater the weight, the more 
+                # denoising (at the expense of fidelity to image).
                 weight: 1
             # Window size for filtering.
             line_per_block: 1000

--- a/src/dswx_sar/defaults/algorithm_parameter_s1.yaml
+++ b/src/dswx_sar/defaults/algorithm_parameter_s1.yaml
@@ -6,12 +6,12 @@ runconfig:
         dswx_workflow: 'opera_dswx_s1'
         # Polarizations to be used for DSWx-SAR
         # [polarizations] for list of specific frequency(s) e.g. [VV, VH] or [VV]
-        # 'dual-pol', 'co-pol', 'cross-pol' will search the polarizations Input GeoTiff files have. 
-        # For example, 'co-pol' uses ['HH'], ['VV'], or ['HH', 'VV'] by looking at the input data. 
+        # 'dual-pol', 'co-pol', 'cross-pol' will search the polarizations Input GeoTiff files have.
+        # For example, 'co-pol' uses ['HH'], ['VV'], or ['HH', 'VV'] by looking at the input data.
         # ['auto'] will detect available polarizations from given RTC data
         polarizations: ['auto']
         # Additional for polarimetric computations to be performed in specific polarization modes (co/cross and co + cross)
-        # e.g. ['ratio', 'span'] 
+        # e.g. ['ratio', 'span']
         polarimetric_option:
 
         # Specifiy the max_value for permanent water and no_data_value for invalid pixels
@@ -103,12 +103,12 @@ runconfig:
             # estimate single threshold per tile. If True, the trimodal distribution is assumed,
             # the lowest threshold is estimated.
             multi_threshold: True
-            # Flag to adjust threshold where two gaussian distribution is not overlapped. 
+            # Flag to adjust threshold where two gaussian distribution is not overlapped.
             # If 'adjust_if_nonoverlap' is enabled,
             # start to search the alternative threshold when two distributions are not
             # overlapped. The 'low_dist_percentile' is the percentile of
             # the low distribution and 'high_dist_percentile' is the percentile of
-            # the high distribution. Both values should be within range of 0 to 1.             
+            # the high distribution. Both values should be within range of 0 to 1.
             adjust_if_nonoverlap: True
             low_dist_percentile: 0.99
             high_dist_percentile: 0.01
@@ -165,8 +165,8 @@ runconfig:
             line_per_block: 400
 
         masking_ancillary:
-            # Land covers that behaves like dark lands in DSWx-SAR. 
-            # The elements should be in given landcover file. 
+            # Land covers that behaves like dark lands in DSWx-SAR.
+            # The elements should be in given landcover file.
             # The elements will be masked out during this step.
             land_cover_darkland_list: ['Bare sparse vegetation', 'Urban', 'Moss and lichen']
             # The elements is considered as the dark land candidates
@@ -209,7 +209,7 @@ runconfig:
             cross_pol_min: -26
             line_per_block: 300
             # If 'auto' is selected and GLAD is available, GLAD will be
-            # used for inundated vegetation. In the 'auto' option, 
+            # used for inundated vegetation. In the 'auto' option,
             # GLAD is not provided, then WorldCover will be used to extract
             # the target areas.
             target_area_file_type: 'auto'
@@ -222,12 +222,21 @@ runconfig:
                 lee_filter:
                     window_size: 3
                 guided_filter:
+                    # Radius of the kernel used in the Guided Filter.
                     radius: 1
+                    # Regularization parameter in Guided Filter to smooth within
+                    # a radius. Default is 3.
                     eps: 3
+                    # The depth of the output image.
                     ddepth: -1
                 bregman:
+                    # The regularization parameter for TV Bregman denoising.
+                    # It controls the amount of smoothing. Higher values
+                    # produce more smoothed results.
                     lambda_value: 20
                 anisotropic_diffusion:
+                    # Denoising weight. The greater the weight, the more
+                    # denoising (at the expense of fidelity to image).
                     weight: 1
                 # Window size for filtering.
                 line_per_block: 1000

--- a/src/dswx_sar/defaults/algorithm_parameter_s1.yaml
+++ b/src/dswx_sar/defaults/algorithm_parameter_s1.yaml
@@ -208,6 +208,10 @@ runconfig:
             dual_pol_ratio_threshold: 8
             cross_pol_min: -26
             line_per_block: 300
+            # If 'auto' is selected and GLAD is available, GLAD will be
+            # used for inundated vegetation. In the 'auto' option, 
+            # GLAD is not provided, then WorldCover will be used to extract
+            # the target areas.
             target_area_file_type: 'auto'
             target_worldcover_class: ['Herbaceous wetland']
             target_glad_class: ['112-124', '200-207', '19-24', '125-148']

--- a/src/dswx_sar/defaults/algorithm_parameter_s1.yaml
+++ b/src/dswx_sar/defaults/algorithm_parameter_s1.yaml
@@ -208,7 +208,25 @@ runconfig:
             dual_pol_ratio_threshold: 8
             cross_pol_min: -26
             line_per_block: 300
-            target_land_cover: ['Herbaceous wetland']
+            target_area_file_type: 'auto'
+            target_worldcover_land_cover: ['Herbaceous wetland']
+            target_glad_class: ['112-124', '200-207', '19-24', '125-148']
+            filter:
+                enabled: True
+                method: lee
+                block_pad: 300
+                lee_filter:
+                    window_size: 3
+                guided_filter:
+                    radius: 1
+                    eps: 3
+                    ddepth: -1
+                bregman:
+                    lambda_value: 20
+                anisotropic_diffusion:
+                    weight: 1
+                # Window size for filtering.
+                line_per_block: 1000
 
         # debug mode is true, intermediate product is generated.
         debug_mode: False

--- a/src/dswx_sar/defaults/dswx_s1.yaml
+++ b/src/dswx_sar/defaults/dswx_s1.yaml
@@ -26,6 +26,12 @@ runconfig:
             # ESA WorldCover map description
             worldcover_file_description:
 
+            # GLAD classification map file
+            glad_classification_file:
+
+            # GLAD classification map file description
+            glad_classification_file_description:
+
             # Reference water body map (Required)
             # e.g., Pekel's water occurrence or seasonality map
             reference_water_file:

--- a/src/dswx_sar/detect_inundated_vegetation.py
+++ b/src/dswx_sar/detect_inundated_vegetation.py
@@ -55,7 +55,7 @@ def run(cfg):
     t_all = time.time()
 
     processing_cfg = cfg.groups.processing
-    outputdir = cfg.groups.product_path_group.scratch_path
+    scratch_dir = cfg.groups.product_path_group.scratch_path
     pol_list = copy.deepcopy(processing_cfg.polarizations)
     pol_options = processing_cfg.polarimetric_option
 
@@ -79,8 +79,8 @@ def run(cfg):
     filter_options = inundated_vege_cfg.filter
     filter_method = inundated_vege_cfg.filter.method
 
-    interp_glad_path_str = os.path.join(outputdir, 'interpolated_glad.tif')
-    interp_worldcover_path_str = os.path.join(outputdir,
+    interp_glad_path_str = os.path.join(scratch_dir, 'interpolated_glad.tif')
+    interp_worldcover_path_str = os.path.join(scratch_dir,
                                               'interpolated_landcover.tif')
 
     if (target_file_type == 'auto'):
@@ -100,11 +100,11 @@ def run(cfg):
                                          'WorldCover')
     mask_obj = FillMaskLandCover(landcover_path_str, target_file_type)
     inundated_vege_path = \
-        f"{outputdir}/temp_inundated_vegetation_{pol_all_str}.tif"
+        f"{scratch_dir}/temp_inundated_vegetation_{pol_all_str}.tif"
     target_area_path = \
-        f"{outputdir}/temp_target_area_{pol_all_str}.tif"
+        f"{scratch_dir}/temp_target_area_{pol_all_str}.tif"
     high_ratio_path = \
-        f"{outputdir}/temp_high_dualpol_ratio_{pol_all_str}.tif"
+        f"{scratch_dir}/temp_high_dualpol_ratio_{pol_all_str}.tif"
 
     dual_pol_flag = False
     if (('HH' in pol_list) and ('HV' in pol_list)) or \
@@ -129,7 +129,7 @@ def run(cfg):
         elif pol in ['HV', 'VH']:
             crosspol_ind = polind
 
-    rtc_dual_path = f"{outputdir}/filtered_image_{pol_all_str}.tif"
+    rtc_dual_path = f"{scratch_dir}/filtered_image_{pol_all_str}.tif"
     if not os.path.isfile(rtc_dual_path):
         err_str = f'{rtc_dual_path} is not found.'
         raise FileExistsError(err_str)
@@ -196,7 +196,7 @@ def run(cfg):
                 block_param=block_param)
 
             # GLAD has no-data values for small island and polar regions
-            # such Green land. The WorldCover will be alternatively used
+            # such as Greenland. The WorldCover will be alternatively used
             # for the no-data areas.
             glad_no_data = mask_obj.get_mask(
                 mask_label=[255],
@@ -205,8 +205,9 @@ def run(cfg):
             target_replace_class = sup_mask_obj.get_mask(
                 mask_label=target_worldcover_class,
                 block_param=block_param)
-            target_inundated_vege_class[glad_no_data] = \
-                target_replace_class[glad_no_data]
+            target_inundated_vege_class[
+                glad_no_data & target_replace_class] = 2
+                # target_replace_class[glad_no_data]
 
         no_data = np.isnan(filt_ratio)
         target_inundated_vege_class[no_data] = 0
@@ -226,7 +227,7 @@ def run(cfg):
             projection=im_meta['projection'],
             datatype='byte',
             cog_flag=True,
-            scratch_dir=outputdir)
+            scratch_dir=scratch_dir)
 
         dswx_sar_util.write_raster_block(
             out_raster=target_area_path,
@@ -236,7 +237,7 @@ def run(cfg):
             projection=im_meta['projection'],
             datatype='byte',
             cog_flag=True,
-            scratch_dir=outputdir)
+            scratch_dir=scratch_dir)
 
         dswx_sar_util.write_raster_block(
             out_raster=high_ratio_path,
@@ -246,21 +247,21 @@ def run(cfg):
             projection=im_meta['projection'],
             datatype='byte',
             cog_flag=True,
-            scratch_dir=outputdir)
+            scratch_dir=scratch_dir)
 
         if processing_cfg.debug_mode:
             dswx_sar_util.write_raster_block(
                 out_raster=os.path.join(
-                    outputdir, f'intensity_db_ratio_{pol_all_str}.tif'),
+                    scratch_dir, f'intensity_db_ratio_{pol_all_str}.tif'),
                 data=filt_ratio_db,
                 block_param=block_param,
                 geotransform=im_meta['geotransform'],
                 projection=im_meta['projection'],
                 datatype='float32',
                 cog_flag=True,
-                scratch_dir=outputdir)
+                scratch_dir=scratch_dir)
 
-    dswx_sar_util._save_as_cog(inundated_vege_path, outputdir)
+    dswx_sar_util._save_as_cog(inundated_vege_path, scratch_dir)
 
     t_time_end = time.time()
 

--- a/src/dswx_sar/detect_inundated_vegetation.py
+++ b/src/dswx_sar/detect_inundated_vegetation.py
@@ -189,6 +189,9 @@ def run(cfg):
             target_inundated_vege_class[glad_no_data] = \
                 target_replace_class[glad_no_data]
 
+        no_data = np.isnan(filt_ratio)
+        target_inundated_vege_class[no_data] = 0
+
         all_inundated_cand = \
             (filt_ratio_db > inundated_vege_ratio_threshold) & \
             target_cross_pol

--- a/src/dswx_sar/detect_inundated_vegetation.py
+++ b/src/dswx_sar/detect_inundated_vegetation.py
@@ -17,7 +17,26 @@ logger = logging.getLogger('dswx_sar')
 def parse_ranges(ranges):
     """
     Parse a list of ranges in the format "start-end" and single numbers.
-    Return a list of integers.
+
+    Parameters
+    ----------
+    ranges : list of str
+        A list of strings where each string is either a single number or a
+        range in the format "start-end".
+
+    Returns
+    -------
+    result : list of int
+        A list of integers that includes all numbers in the specified ranges
+        and single numbers.
+
+    Examples
+    --------
+    >>> parse_ranges(["1-3", "5", "7-9"])
+    [1, 2, 3, 5, 7, 8, 9]
+
+    >>> parse_ranges(["10", "12-15", "18"])
+    [10, 12, 13, 14, 15, 18]
     """
     result = []
     for item in ranges:
@@ -175,10 +194,10 @@ def run(cfg):
             target_inundated_vege_class = mask_obj.get_mask(
                 mask_label=inundated_vege_target,
                 block_param=block_param)
-            
+
             # GLAD has no-data values for small island and polar regions
             # such Green land. The WorldCover will be alternatively used
-            # for the no-data areas. 
+            # for the no-data areas.
             glad_no_data = mask_obj.get_mask(
                 mask_label=[255],
                 block_param=block_param)

--- a/src/dswx_sar/detect_inundated_vegetation.py
+++ b/src/dswx_sar/detect_inundated_vegetation.py
@@ -53,7 +53,7 @@ def run(cfg):
     inundated_vege_cross_pol_min = inundated_vege_cfg.cross_pol_min
 
     target_file_type = inundated_vege_cfg.target_area_file_type
-    target_worldcover_land_cover = inundated_vege_cfg.target_worldcover_land_cover
+    target_worldcover_class = inundated_vege_cfg.target_worldcover_class
     target_glad_class = inundated_vege_cfg.target_glad_class
 
     line_per_block = inundated_vege_cfg.line_per_block
@@ -161,11 +161,10 @@ def run(cfg):
         target_cross_pol = cross_db > inundated_vege_cross_pol_min
         if target_file_type == 'WorldCover':
             target_inundated_vege_class = mask_obj.get_mask(
-                mask_label=target_worldcover_land_cover,
+                mask_label=target_worldcover_class,
                 block_param=block_param)
         elif target_file_type == 'GLAD':
             inundated_vege_target = parse_ranges(target_glad_class)
-            print(inundated_vege_target)
             target_inundated_vege_class = mask_obj.get_mask(
                 mask_label=inundated_vege_target,
                 block_param=block_param)

--- a/src/dswx_sar/detect_inundated_vegetation.py
+++ b/src/dswx_sar/detect_inundated_vegetation.py
@@ -83,7 +83,7 @@ def run(cfg):
     interp_worldcover_path_str = os.path.join(scratch_dir,
                                               'interpolated_landcover.tif')
 
-    if (target_file_type == 'auto'):
+    if target_file_type == 'auto':
         if os.path.exists(interp_glad_path_str):
             target_file_type = 'GLAD'
         else:
@@ -91,7 +91,7 @@ def run(cfg):
     logger.info(f'Vegetation area is extracted from {target_file_type}.')
 
     # Currently, inundated vegetation for C-band is available for
-    # Herbanceous wetland area
+    # Potential wetland area from Land cover maps
     if target_file_type == 'WorldCover':
         landcover_path_str = interp_worldcover_path_str
     else:

--- a/src/dswx_sar/dswx_ni_runconfig.py
+++ b/src/dswx_sar/dswx_ni_runconfig.py
@@ -20,7 +20,7 @@ WORKFLOW_SCRIPTS_DIR = os.path.dirname(dswx_sar.__file__)
 # Potential polarization scenarios for DSWx-S1
 # NOTE: DO NOT CHANGE THE ORDER of the items in the dictionary below.
 # TODO: Need to update dictionary for NISAR
-DSWX_S1_POL_DICT = {
+DSWX_NI_POL_DICT = {
     'CO_POL': ['HH', 'VV'],
     'CROSS_POL': ['HV', 'VH'],
     'MIX_DUAL_POL': ['HH', 'HV', 'VV', 'VH'],
@@ -328,11 +328,15 @@ def validate_group_dict(group_cfg: dict) -> None:
                     'dynamic_ancillary_file_group']['reference_water_file']
     hand_path = group_cfg[
                     'dynamic_ancillary_file_group']['hand_file']
+    glad_path = group_cfg[
+                    'dynamic_ancillary_file_group']['glad_classification_file']
     ancillary_file_paths = [dem_path, landcover_path,
-                            ref_water_path, hand_path]
+                            ref_water_path, hand_path,
+                            glad_path]
 
     for path in ancillary_file_paths:
-        check_file_path(path)
+        if path is not None:
+            check_file_path(path)
 
     # Check 'product_group' section of runconfig.
     # Check that directories herein have writing permissions

--- a/src/dswx_sar/dswx_runconfig.py
+++ b/src/dswx_sar/dswx_runconfig.py
@@ -326,11 +326,15 @@ def validate_group_dict(group_cfg: dict) -> None:
                     'dynamic_ancillary_file_group']['reference_water_file']
     hand_path = group_cfg[
                     'dynamic_ancillary_file_group']['hand_file']
+    glad_path = group_cfg[
+                    'dynamic_ancillary_file_group']['glad_classification_file']
     ancillary_file_paths = [dem_path, landcover_path,
-                            ref_water_path, hand_path]
+                            ref_water_path, hand_path,
+                            glad_path]
 
     for path in ancillary_file_paths:
-        check_file_path(path)
+        if path is not None:
+            check_file_path(path)
 
     # Check 'product_group' section of runconfig.
     # Check that directories herein have writing permissions

--- a/src/dswx_sar/dswx_sar_util.py
+++ b/src/dswx_sar/dswx_sar_util.py
@@ -278,7 +278,7 @@ def save_dswx_product(wtr, output_file, geotransform,
     sorted_band_keys = sorted(
         band_value_dict.keys(),
         key=lambda x: x.lower() == 'inundated_vegetation')
-    print(sorted_band_keys)
+
     for band_key in sorted_band_keys:
         if band_key.lower() in dswx_processed_bands_keys:
             dswx_product_value = band_value_dict[band_key]

--- a/src/dswx_sar/dswx_sar_util.py
+++ b/src/dswx_sar/dswx_sar_util.py
@@ -34,6 +34,12 @@ band_assign_value_dict = {
     'inundated_vegetation': 3,
     'dark_land_mask': 5,
     'landcover_mask': 6,
+    'wetland_nonwater': 10,
+    'wetland_water': 11,
+    'wetland_bright_water_fill': 12,
+    'wetland_inundated_veg': 13,
+    'wetland_dark_land_mask': 15,
+    'wetland_landcover_mask': 16,
     'hand_mask': 250,
     'layover_shadow_mask': 251,
     'ocean_mask': 254,
@@ -96,6 +102,7 @@ def get_interpreted_dswx_s1_ctable():
     # create color table
     dswx_ctable = gdal.ColorTable()
 
+    # Non-target areas for Inundated Vegetation
     # set color for each value
     # White - Not water
     dswx_ctable.SetColorEntry(band_assign_value_dict['nonwater'],
@@ -124,9 +131,25 @@ def get_interpreted_dswx_s1_ctable():
     # Green - Inundated vegetation
     dswx_ctable.SetColorEntry(band_assign_value_dict['inundated_vegetation'],
                               (0, 255, 0))
-    # Black - Not observed (out of Boundary)
-    dswx_ctable.SetColorEntry(band_assign_value_dict['no_data'],
-                              (0, 0, 0, 255))
+
+    # Green + gray (Medium Sea Green) - non-wetland_Inundated vegetation
+    dswx_ctable.SetColorEntry(band_assign_value_dict['wetland_inundated_veg'],
+                              (50, 177, 50))
+    # Target areas for Inundated Vegetation
+    dswx_ctable.SetColorEntry(band_assign_value_dict['wetland_nonwater'],
+                              (0, 100, 0))
+    # Blue - Water (high confidence)
+    dswx_ctable.SetColorEntry(band_assign_value_dict['wetland_water'],
+                              (0, 50, 127))
+    # Steel Teal - bright water
+    dswx_ctable.SetColorEntry(band_assign_value_dict['wetland_bright_water_fill'],
+                              (60, 110, 120))
+    # Sepia - dark land
+    dswx_ctable.SetColorEntry(band_assign_value_dict['wetland_dark_land_mask'],
+                              (120, 60, 20))
+    # Olive Drab
+    dswx_ctable.SetColorEntry(band_assign_value_dict['wetland_landcover_mask'],
+                              (100, 150, 25))
 
     return dswx_ctable
 
@@ -255,7 +278,7 @@ def save_dswx_product(wtr, output_file, geotransform,
     sorted_band_keys = sorted(
         band_value_dict.keys(),
         key=lambda x: x.lower() == 'inundated_vegetation')
-
+    print(sorted_band_keys)
     for band_key in sorted_band_keys:
         if band_key.lower() in dswx_processed_bands_keys:
             dswx_product_value = band_value_dict[band_key]

--- a/src/dswx_sar/dswx_sar_util.py
+++ b/src/dswx_sar/dswx_sar_util.py
@@ -32,14 +32,15 @@ band_assign_value_dict = {
     'water': 1,  # water body
     'bright_water_fill': 2,
     'inundated_vegetation': 3,
-    'dark_land_mask': 5,
-    'landcover_mask': 6,
-    'wetland_nonwater': 10,
-    'wetland_water': 11,
-    'wetland_bright_water_fill': 12,
-    'wetland_inundated_veg': 13,
-    'wetland_dark_land_mask': 15,
-    'wetland_landcover_mask': 16,
+    'inundated_vegetation_conf': 5,
+    'dark_land_mask': 6,
+    'landcover_mask': 7,
+    'wetland_nonwater': 30,
+    'wetland_water': 31,
+    'wetland_bright_water_fill': 32,
+    'wetland_inundated_veg': 35,
+    'wetland_dark_land_mask': 36,
+    'wetland_landcover_mask': 37,
     'hand_mask': 250,
     'layover_shadow_mask': 251,
     'ocean_mask': 254,
@@ -130,6 +131,8 @@ def get_interpreted_dswx_s1_ctable():
                               (128, 128, 128))
     # Green - Inundated vegetation
     dswx_ctable.SetColorEntry(band_assign_value_dict['inundated_vegetation'],
+                              (0, 255, 0))
+    dswx_ctable.SetColorEntry(band_assign_value_dict['inundated_vegetation_conf'],
                               (0, 255, 0))
 
     # Green + gray (Medium Sea Green) - non-wetland_Inundated vegetation

--- a/src/dswx_sar/metadata.py
+++ b/src/dswx_sar/metadata.py
@@ -143,8 +143,11 @@ def _populate_ancillary_metadata_datasets(dswx_metadata_dict, ancillary_cfg):
         'INPUT_SHORELINE_SOURCE': ('shoreline_shapefile',
                                    'shoreline_shapefile_description'),
         'INPUT_REFERENCE_WATER_SOURCE': ('reference_water_file',
-                                         'reference_water_file_description')
-    }
+                                         'reference_water_file_description'),
+        'INPUT_GLAD_CLASSIFICATION_SOURCE':
+            ('glad_classification_file',
+             'glad_classification_file_description')
+        }
 
     for meta_key, (file_attr, desc_attr) in source_map.items():
         description = getattr(ancillary_cfg, desc_attr, None)
@@ -198,6 +201,13 @@ def _populate_processing_metadata_datasets(dswx_metadata_dict, cfg):
         elif filter_method == 'bregman':
             filter_option = {'lambda':
                              filter_opt.bregman.lambda_value}
+
+        if inundated_vegetation_cfg.target_area_file_type == 'WorldCover':
+            inundated_vege_target_class = \
+                inundated_vegetation_cfg.target_worldcover_land_cover
+        elif inundated_vegetation_cfg.target_area_file_type == 'GLAD':
+            inundated_vege_target_class = \
+                inundated_vegetation_cfg.target_glad_class
 
         dswx_metadata_dict.update({
             'PROCESSING_INFORMATION_POLARIZATION':
@@ -269,9 +279,12 @@ def _populate_processing_metadata_datasets(dswx_metadata_dict, cfg):
                 inundated_vegetation_cfg.dual_pol_ratio_min,
             'PROCESSING_INFORMATION_INUNDATED_VEGETATION_DUAL_POL_RATIO_THRESHOLD':
                 inundated_vegetation_cfg.dual_pol_ratio_threshold,
-            'PROCESSING_INFORMATION_INUNDATED_VEGETATION_CROSS_POL_MIN':
-                inundated_vegetation_cfg.cross_pol_min
-
+            'PROCESSING_INFORMATION_INUNDATED_VEGETATION_AREA_DATA_TYPE':
+                inundated_vegetation_cfg.target_area_file_type,
+            'PROCESSING_INFORMATION_INUNDATED_VEGETATION_TARGET_CLASS':
+                inundated_vege_target_class,
+            'PROCESSING_INFORMATION_INUNDATED_VEGETATION_FILTER':
+                inundated_vegetation_cfg.filter.method
         })
     except AttributeError as e:
         print(f"Attribute error occurred: {e}")
@@ -459,7 +472,7 @@ def collect_burst_id(rtc_dirs, pol):
     return list(set(burst_id_list))
 
 
-def create_dswx_sar_metadata(cfg,
+def create_dswx_s1_metadata(cfg,
                              rtc_dirs,
                              product_version=None,
                              extra_meta_data=None):

--- a/src/dswx_sar/metadata.py
+++ b/src/dswx_sar/metadata.py
@@ -204,7 +204,7 @@ def _populate_processing_metadata_datasets(dswx_metadata_dict, cfg):
 
         if inundated_vegetation_cfg.target_area_file_type == 'WorldCover':
             inundated_vege_target_class = \
-                inundated_vegetation_cfg.target_worldcover_land_cover
+                inundated_vegetation_cfg.target_worldcover_class
         elif inundated_vegetation_cfg.target_area_file_type == 'GLAD':
             inundated_vege_target_class = \
                 inundated_vegetation_cfg.target_glad_class

--- a/src/dswx_sar/metadata.py
+++ b/src/dswx_sar/metadata.py
@@ -202,10 +202,12 @@ def _populate_processing_metadata_datasets(dswx_metadata_dict, cfg):
             filter_option = {'lambda':
                              filter_opt.bregman.lambda_value}
 
+        # Three options are possible. 'WorldCover', 'GLAD', 'auto'
+        # Currently, GLAD will be used for 'auto'.
         if inundated_vegetation_cfg.target_area_file_type == 'WorldCover':
             inundated_vege_target_class = \
                 inundated_vegetation_cfg.target_worldcover_class
-        elif inundated_vegetation_cfg.target_area_file_type == 'GLAD':
+        else:
             inundated_vege_target_class = \
                 inundated_vegetation_cfg.target_glad_class
 

--- a/src/dswx_sar/metadata.py
+++ b/src/dswx_sar/metadata.py
@@ -176,14 +176,14 @@ def _populate_processing_metadata_datasets(dswx_metadata_dict, cfg):
         threshold_mapping = {
             'otsu': 'OTSU',
             'ki': 'Kittler-Illingworth',
-            'rg': 'Region-growning based threshold'
+            'rg': 'Region-growing based threshold'
         }
         initial_threshold_cfg = processing_cfg.initial_threshold
         masking_ancillary_cfg = processing_cfg.masking_ancillary
         fuzzy_value_cfg = processing_cfg.fuzzy_value
         inundated_vegetation_cfg = processing_cfg.inundated_vegetation
         refine_with_bimodality_cfg = processing_cfg.refine_with_bimodality
-        filter_method = processing_cfg.filter.method 
+        filter_method = processing_cfg.filter.method
         filter_opt = processing_cfg.filter
         if filter_method == 'lee':
             filter_option = {'win_size':

--- a/src/dswx_sar/pre_processing.py
+++ b/src/dswx_sar/pre_processing.py
@@ -595,6 +595,7 @@ def run(cfg):
     landcover_file = dynamic_data_cfg.worldcover_file
     dem_file = dynamic_data_cfg.dem_file
     hand_file = dynamic_data_cfg.hand_file
+    glad_file = dynamic_data_cfg.glad_classification_file
 
     ref_water_max = processing_cfg.reference_water.max_value
     ref_water_no_data = processing_cfg.reference_water.no_data_value
@@ -660,6 +661,7 @@ def run(cfg):
         'hand': 'interpolated_hand.tif',
         'landcover': 'interpolated_landcover.tif',
         'reference_water': 'interpolated_wbd.tif',
+        'glad_classification': 'interpolated_glad.tif',
     }
 
     input_ancillary_filename_set = {
@@ -667,6 +669,7 @@ def run(cfg):
         'hand': hand_file,
         'landcover': landcover_file,
         'reference_water': wbd_file,
+        'glad_classification': glad_file,
     }
 
     landcover_label = get_label_landcover_esa_10()
@@ -675,6 +678,10 @@ def run(cfg):
         input_anc_path = input_ancillary_filename_set[anc_type]
         ancillary_path = Path(
             os.path.join(scratch_dir, anc_filename))
+
+        # GLAD classification map is optional.
+        if input_anc_path is None and anc_type == 'glad_classification':
+            continue
 
         # Check if input ancillary data is valid.
         if not os.path.isfile(input_anc_path) and \
@@ -803,7 +810,6 @@ def run(cfg):
                     elif filter_method == 'bregman':
                         filtering_method = filter_SAR.tv_bregman
                         filter_option = vars(filter_options.bregman)
-                    print(filter_option)
                     filtered_intensity = filtering_method(
                                                 intensity, **filter_option)
                 else:

--- a/src/dswx_sar/pre_processing.py
+++ b/src/dswx_sar/pre_processing.py
@@ -679,6 +679,7 @@ def run(cfg):
 
         # GLAD classification map is optional.
         if input_anc_path is None and anc_type == 'glad_classification':
+            logger.info(f'{anc_type} file is not provided.')
             continue
 
         # Check if input ancillary data is valid.

--- a/src/dswx_sar/pre_processing.py
+++ b/src/dswx_sar/pre_processing.py
@@ -324,7 +324,6 @@ class AncillaryRelocation:
         file_min_x, file_dx, _, file_max_y, _, file_dy = file_geotransform
 
         file_width = gdal_ds.GetRasterBand(1).XSize
-        file_length = gdal_ds.GetRasterBand(1).YSize
 
         del gdal_ds
         file_srs = osr.SpatialReference()
@@ -371,7 +370,6 @@ class AncillaryRelocation:
         logger.info('    tile crosses the antimeridian')
 
         file_max_x = file_min_x + file_width * file_dx
-        file_min_y = file_max_y + file_length * file_dy
 
         # Crop input at the two sides of the antimeridian:
         # left side: use tile bbox with file_max_x from input
@@ -693,6 +691,8 @@ def run(cfg):
             no_data = ref_water_no_data
         elif anc_type in ['landcover']:
             no_data = landcover_label['No_data']
+        elif anc_type in ['glad_classification']:
+            no_data = 255
         else:
             no_data = np.nan
 
@@ -801,7 +801,8 @@ def run(cfg):
 
                     elif filter_method == 'anisotropic_diffusion':
                         filtering_method = filter_SAR.anisotropic_diffusion
-                        filter_option = vars(filter_options.anisotropic_diffusion)
+                        filter_option = vars(
+                            filter_options.anisotropic_diffusion)
 
                     elif filter_method == 'guided_filter':
                         filtering_method = filter_SAR.guided_filter

--- a/src/dswx_sar/save_mgrs_tiles.py
+++ b/src/dswx_sar/save_mgrs_tiles.py
@@ -804,8 +804,6 @@ def run(cfg):
                 glad_valid = np.nansum(inundated_vege_target_area == 1)
                 # If some pixels are extracted from WorldCover,
                 # IV source is GLAD/WorldCover
-                print('worldcover', worldcover_valid)
-                print('glad_valid', glad_valid)
                 if worldcover_valid > 0 and glad_valid > 0:
                     inundated_vege_cfg.target_area_file_type = 'GLAD/WorldCover'
                 # If the GLAD is provided but all pixels come from 'WorldCover'
@@ -813,16 +811,17 @@ def run(cfg):
                 # IV source is WorldCover
                 elif worldcover_valid > 0 and glad_valid == 0:
                     inundated_vege_cfg.target_area_file_type = 'WorldCover'
-                print(inundated_vege_cfg.target_area_file_type)
             else:
                 inundated_vege_cfg.target_area_file_type = 'WorldCover'
-        
+        logger.info('Inundated vegetation areas are defined from  '
+                    f'{inundated_vege_cfg.target_area_file_type}.')
+
     else:
         inundated_vegetation = None
         inundated_vege_target_area = None
         inundated_vege_high_ratio = None
         inundated_vegetation_mask = None
-        logger.warning('Inundated vegetation file was disabled.')
+        logger.info('Inundated vegetation file was disabled.')
 
     # 5) create ocean mask
     if ocean_mask_enabled:
@@ -900,7 +899,7 @@ def run(cfg):
             landcover_mask=landcover_mask,
             bright_water_fill=bright_water_mask,
             dark_land_mask=dark_land_mask,
-            inundated_vegetation=(inundated_vege_high_ratio == 1) &
+            inundated_vegetation_conf=(inundated_vege_high_ratio == 1) &
                 (wetland == 0) & (water_map == 0),
             wetland_nonwater=(water_map == 0) & wetland,
             wetland_water=(water_map == 1) & wetland,

--- a/src/dswx_sar/save_mgrs_tiles.py
+++ b/src/dswx_sar/save_mgrs_tiles.py
@@ -727,7 +727,9 @@ def run(cfg):
                 extra_args = {'nodata_value': -1}
             else:
                 extra_args = {'nodata_value': 0}
-            if not inundated_vege_mosaic_flag and key == 'inundated_veg':
+            if not inundated_vege_mosaic_flag and \
+                key in ['inundated_veg', 'inundated_veg_target',
+                        'inundated_veg_high_ratio']:
                 dual_pol_vege_string = '_'.join(pol_set1)
                 paths[key] = os.path.join(
                     scratch_dir, f'{prefix}_{dual_pol_vege_string}.tif')
@@ -787,6 +789,9 @@ def run(cfg):
         logger.info('Inudated vegetation file was found.')
     else:
         inundated_vegetation = None
+        inundated_vege_target_area = None
+        inundated_vege_high_ratio = None
+        inundated_vegetation_mask = None
         logger.warning('Inudated vegetation file was disabled.')
 
     # 5) create ocean mask

--- a/src/dswx_sar/save_mgrs_tiles.py
+++ b/src/dswx_sar/save_mgrs_tiles.py
@@ -710,6 +710,8 @@ def run(cfg):
 
     if total_inundated_vege_flag:
         prefix_dict['inundated_veg'] = 'temp_inundated_vegetation'
+        prefix_dict['inundated_veg_target'] = 'temp_target_area'
+        prefix_dict['inundated_veg_high_ratio'] = 'temp_high_dualpol_ratio'
 
     paths = {}
     for key, prefix in prefix_dict.items():
@@ -775,6 +777,10 @@ def run(cfg):
     if total_inundated_vege_flag:
         inundated_vegetation = dswx_sar_util.read_geotiff(
             paths['inundated_veg'])
+        inundated_vege_target_area = dswx_sar_util.read_geotiff(
+            paths['inundated_veg_target'])
+        inundated_vege_high_ratio = dswx_sar_util.read_geotiff(
+            paths['inundated_veg_high_ratio'])
         inundated_vegetation_mask = (inundated_vegetation == 2) & \
                                     (water_map == 1)
         inundated_vegetation[inundated_vegetation_mask] = 1
@@ -809,7 +815,7 @@ def run(cfg):
         landcover_mask = (region_grow_map == 1) & (landcover_map != 1)
         dark_land_mask = (landcover_map == 1) & (water_map == 0)
         bright_water_mask = (landcover_map == 0) & (water_map == 1)
-
+        wetland = inundated_vege_target_area == 1
         # Open water/inundated vegetation
         # layover shadow mask/hand mask/no_data
         # will be saved in WTR product
@@ -859,10 +865,18 @@ def run(cfg):
             landcover_mask=landcover_mask,
             bright_water_fill=bright_water_mask,
             dark_land_mask=dark_land_mask,
+            inundated_vegetation=(inundated_vege_high_ratio == 1) &
+                (wetland == 0) & (water_map == 0),
+            wetland_nonwater=(water_map == 0) & wetland,
+            wetland_water=(water_map == 1) & wetland,
+            wetland_bright_water_fill=bright_water_mask & wetland,
+            wetland_inundated_veg=(inundated_vegetation == 2) &
+                wetland,
+            wetland_dark_land_mask=dark_land_mask & wetland,
+            wetland_landcover_mask=landcover_mask & wetland,
             layover_shadow_mask=layover_shadow_mask > 0,
             hand_mask=hand_mask,
             ocean_mask=ocean_mask,
-            inundated_vegetation=inundated_vegetation == 2,
             no_data=no_data_raster,
             )
 

--- a/src/dswx_sar/save_mgrs_tiles.py
+++ b/src/dswx_sar/save_mgrs_tiles.py
@@ -24,7 +24,7 @@ from dswx_sar import (dswx_sar_util,
 from dswx_sar.dswx_sar_util import (band_assign_value_dict,
                                     _create_ocean_mask)
 from dswx_sar.dswx_runconfig import RunConfig, _get_parser, DSWX_S1_POL_DICT
-from dswx_sar.metadata import (create_dswx_sar_metadata,
+from dswx_sar.metadata import (create_dswx_s1_metadata,
                                collect_burst_id,
                                _populate_statics_metadata_datasets)
 
@@ -958,7 +958,7 @@ def run(cfg):
 
             # Metadata
             if overlapped_burst:
-                dswx_metadata_dict = create_dswx_sar_metadata(
+                dswx_metadata_dict = create_dswx_s1_metadata(
                     cfg,
                     overlapped_burst,
                     product_version=product_version,

--- a/src/dswx_sar/schemas/algorithm_parameter_ni.yaml
+++ b/src/dswx_sar/schemas/algorithm_parameter_ni.yaml
@@ -14,7 +14,7 @@ runconfig:
         # Additional for polarimetric computations to be performed in specific polarization modes (co/cross and co + cross)
         polarimetric_option: any(list(enum('ratio', 'span'), min=1, max=2), enum('ratio', 'span'), null(), required=False)
 
-        # Specifiy the max_value for permanent water and no_data_value for invalid pixels
+        # Specify the max_value for permanent water and no_data_value for invalid pixels
         reference_water:
             max_value: num(required=False)
             no_data_value: num(required=False)

--- a/src/dswx_sar/schemas/algorithm_parameter_s1.yaml
+++ b/src/dswx_sar/schemas/algorithm_parameter_s1.yaml
@@ -14,7 +14,7 @@ runconfig:
         # Additional for polarimetric computations to be performed in specific polarization modes (co/cross and co + cross)
         polarimetric_option: any(list(enum('ratio', 'span'), min=1, max=2), enum('ratio', 'span'), null(), required=False)
 
-        # Specifiy the max_value for permanent water and no_data_value for invalid pixels
+        # Specify the max_value for permanent water and no_data_value for invalid pixels
         reference_water:
             max_value: num(required=False)
             no_data_value: num(required=False)

--- a/src/dswx_sar/schemas/algorithm_parameter_s1.yaml
+++ b/src/dswx_sar/schemas/algorithm_parameter_s1.yaml
@@ -47,12 +47,21 @@ runconfig:
             lee_filter:
                 window_size: num(min=1, required=False)
             guided_filter:
+                # Radius of the kernel used in the Guided Filter.
                 radius: num(min=1, required=False)
+                # Regularization parameter in Guided Filter to smooth within
+                # a radius. Default is 3.
                 eps: num(required=False)
+                # The depth of the output image.
                 ddepth: num(required=False)
             bregman:
+                # The regularization parameter for TV Bregman denoising.
+                # It controls the amount of smoothing. Higher values
+                # produce more smoothed results.
                 lambda_value: num(required=False)
             anisotropic_diffusion:
+                # Denoising weight. The greater the weight, the more 
+                # denoising (at the expense of fidelity to image).
                 weight: num(required=False)
 
         initial_threshold:

--- a/src/dswx_sar/schemas/algorithm_parameter_s1.yaml
+++ b/src/dswx_sar/schemas/algorithm_parameter_s1.yaml
@@ -204,7 +204,25 @@ runconfig:
             dual_pol_ratio_threshold: num(min=0, max=30, required=False)
             cross_pol_min: num(min=-30, max=10, required=False)
             line_per_block: num(min=1, required=False)
+            target_area_file_type: enum('WorldCover', 'GLAD', 'auto')
             # Land covers where the inundated vegetation is detected. 
-            target_land_cover: list(required=False)
+            target_worldcover_land_cover: list(required=False)
+            target_glad_class: list(required=False)
+            filter:
+                enabled: bool(required=False)
+                method: str(required=False)
+                line_per_block: num(min=1, required=False)
+                block_pad: num(min=1, required=False)
+                lee_filter:
+                    window_size: num(min=1, required=False)
+                guided_filter:
+                    radius: num(min=1, required=False)
+                    eps: num(required=False)
+                    ddepth: num(required=False)
+                bregman:
+                    lambda_value: num(required=False)
+                anisotropic_diffusion:
+                    weight: num(required=False)
+
         # If debug mode is true, intermediate product is generated.
         debug_mode: bool(required=False)

--- a/src/dswx_sar/schemas/algorithm_parameter_s1.yaml
+++ b/src/dswx_sar/schemas/algorithm_parameter_s1.yaml
@@ -206,7 +206,7 @@ runconfig:
             line_per_block: num(min=1, required=False)
             target_area_file_type: enum('WorldCover', 'GLAD', 'auto')
             # Land covers where the inundated vegetation is detected. 
-            target_worldcover_land_cover: list(required=False)
+            target_worldcover_class: list(required=False)
             target_glad_class: list(required=False)
             filter:
                 enabled: bool(required=False)

--- a/src/dswx_sar/schemas/algorithm_parameter_s1.yaml
+++ b/src/dswx_sar/schemas/algorithm_parameter_s1.yaml
@@ -204,6 +204,10 @@ runconfig:
             dual_pol_ratio_threshold: num(min=0, max=30, required=False)
             cross_pol_min: num(min=-30, max=10, required=False)
             line_per_block: num(min=1, required=False)
+            # If 'auto' is selected and GLAD is available, GLAD will be
+            # used for inundated vegetation. In the 'auto' option, 
+            # GLAD is not provided, then WorldCover will be used to extract
+            # the target areas.
             target_area_file_type: enum('WorldCover', 'GLAD', 'auto')
             # Land covers where the inundated vegetation is detected. 
             target_worldcover_class: list(required=False)

--- a/src/dswx_sar/schemas/dswx_s1.yaml
+++ b/src/dswx_sar/schemas/dswx_s1.yaml
@@ -35,6 +35,12 @@ runconfig:
             # ESA WorldCover map description
             worldcover_file_description: str(required=False)
 
+            # GLAD classification map file
+            glad_classification_file: str(required=False)
+
+            # GLAD classification map file description
+            glad_classification_file_description: str(required=False)
+
             # NOAA GSHHS shapefile
             shoreline_shapefile: str(required=False)
 


### PR DESCRIPTION
This PR adds GLAD classification map as the additional ancillary input for the inundated vegetation.  

- GLAD is not affecting to the open water algorithm. 
- GLAD is the optional input. If GLAD is not given, the Worldcover map should be used to define the Herbaceous Wetland. 
- Thus, 'auto' in `target_area_file_type: enum('WorldCover', 'GLAD', 'auto')` will determine what is available. The GLAD is available, then code choose the GLAD as the main product. If not, 'WorldCover' is chosen. 

**Additional commits**
- CONF layer is modified 
![image](https://github.com/opera-adt/DSWX-SAR/assets/56169931/caf3cfb2-0815-431c-a0e9-d0a77ba4d4fb)
![image](https://github.com/opera-adt/DSWX-SAR/assets/56169931/962d55aa-5fb6-4ac1-adcd-0f65dc7beb31)



