### PR TITLE
Add mgrs_tile_collection_id in input group of runconfig

### DIFF
--- a/src/dswx_sar/defaults/dswx_s1.yaml
+++ b/src/dswx_sar/defaults/dswx_s1.yaml
@@ -12,6 +12,9 @@ runconfig:
             #            for open water
             input_file_path:
 
+            # Specify the MGRS tile collection ID
+            input_mgrs_collection_id:
+
         dynamic_ancillary_file_group:
             # Digital elevation model (Required)
             dem_file:

--- a/src/dswx_sar/schemas/dswx_s1.yaml
+++ b/src/dswx_sar/schemas/dswx_s1.yaml
@@ -9,6 +9,9 @@ runconfig:
             # REQUIRED - list of RTC products (directory or files)
             input_file_path: list(str(), min=1)
 
+            # Specify the MGRS tile collection ID
+            input_mgrs_collection_id: str(required=False)
+
         dynamic_ancillary_file_group:
             # Digital elevation model
             dem_file: str(required=True)


### PR DESCRIPTION
This PR fixes the issue that jobs in high-latitude areas generates unexpected MGRS products when some bursts are missing. To solve the issue, we add one more parameter specifying the MGRS tile collection ID. By specifying the `MGRS tile collection ID`, the additional step searching the `MGRS_set_id` from database can be skipped and reduce the complexity in computing the area. 