### PR TITLE
[DSWx-NI] MGRS products generation from input MGRS collection ID. 

### DIFF
--- a/src/dswx_sar/metadata.py
+++ b/src/dswx_sar/metadata.py
@@ -479,6 +479,35 @@ def collect_burst_id(rtc_dirs, pol):
     return list(set(burst_id_list))
 
 
+def collect_track_frame_id(h5_list):
+    """
+    Collect burst IDs from RTC files for a specific polarization.
+
+    Parameters
+    ----------
+    h5_list : list
+        List of RTC HDF5 files
+    pol : str
+        The polarization for which to collect burst IDs
+        (e.g., 'HH', 'VV', 'HV', 'VH').
+
+    Returns
+    -------
+    list
+        A list of unique burst IDs found in the RTC files
+        for the specified polarization.
+    """
+    burst_id_list = []
+    for rtc_file in h5_list:
+        with h5py.open(rtc_file) as src:
+            # Accessing tags (additional metadata) of specific band
+            # (e.g., band 1)
+            tags = src.tags(0)
+            burst_id_list.append(tags['BURST_ID'])
+
+    return list(set(burst_id_list))
+
+
 def create_dswx_s1_metadata(cfg,
                              rtc_dirs,
                              product_version=None,

--- a/src/dswx_sar/metadata.py
+++ b/src/dswx_sar/metadata.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import glob
 import os
 
+import h5py
 import numpy as np
 import rasterio
 
@@ -479,17 +480,14 @@ def collect_burst_id(rtc_dirs, pol):
     return list(set(burst_id_list))
 
 
-def collect_track_frame_id(h5_list):
+def collect_frame_id(h5_list):
     """
-    Collect burst IDs from RTC files for a specific polarization.
+    Collect frame IDs from GCOV files
 
     Parameters
     ----------
     h5_list : list
         List of RTC HDF5 files
-    pol : str
-        The polarization for which to collect burst IDs
-        (e.g., 'HH', 'VV', 'HV', 'VH').
 
     Returns
     -------
@@ -497,15 +495,13 @@ def collect_track_frame_id(h5_list):
         A list of unique burst IDs found in the RTC files
         for the specified polarization.
     """
-    burst_id_list = []
+    frame_id_list = []
+    frame_path = '/science/LSAR/identification/frameNumber'
     for rtc_file in h5_list:
-        with h5py.open(rtc_file) as src:
-            # Accessing tags (additional metadata) of specific band
-            # (e.g., band 1)
-            tags = src.tags(0)
-            burst_id_list.append(tags['BURST_ID'])
-
-    return list(set(burst_id_list))
+        with h5py.File(rtc_file) as src:
+            frame = src[frame_path][()]
+            frame_id_list.append(frame)
+    return list(set(frame_id_list))
 
 
 def create_dswx_s1_metadata(cfg,

--- a/src/dswx_sar/save_mgrs_tiles_ni.py
+++ b/src/dswx_sar/save_mgrs_tiles_ni.py
@@ -275,6 +275,31 @@ def get_intersecting_mgrs_tiles_list_from_db(
     return list(set(mgrs_list)), most_overlapped
 
 
+def get_mgrs_tiles_list_from_db(mgrs_collection_file,
+                                mgrs_tile_collection_id):
+    """Retrieve a list of MGRS tiles from a specified MGRS tile collection.
+
+    Parameters
+    ----------
+    mgrs_collection_file : str
+        Path to the file containing the MGRS tile collection.
+        This file should be readable by GeoPandas.
+    mgrs_tile_collection_id : str
+        The ID of the MGRS tile collection from which to retrieve the MGRS tiles.
+
+    Returns
+    -------
+    mgrs_list : list
+        List of MGRS tile identifiers from the specified collection.
+    """
+    vector_gdf = gpd.read_file(mgrs_collection_file)
+    most_overlapped = vector_gdf[
+        vector_gdf['mgrs_set_id'] == mgrs_tile_collection_id].iloc[0]
+    mgrs_list = ast.literal_eval(most_overlapped['mgrs_tiles'])
+
+    return list(set(mgrs_list)), most_overlapped
+
+
 def run(cfg):
     '''
     Run save mgrs tiles with parameters in cfg dictionary
@@ -307,6 +332,8 @@ def run(cfg):
     cross_pol = processing_cfg.crosspol
 
     input_list = cfg.groups.input_file_group.input_file_path
+    input_mgrs_collection_id = \
+        cfg.groups.input_file_group.input_mgrs_collection_id
     dswx_workflow = processing_cfg.dswx_workflow
     hand_mask_value = processing_cfg.hand.mask_value
 
@@ -747,12 +774,25 @@ def run(cfg):
     mgrs_meta_dict = {}
 
     if database_bool:
-        mgrs_tile_list, most_overlapped = \
-            get_intersecting_mgrs_tiles_list_from_db(
-                mgrs_collection_file=mgrs_collection_db_path,
-                image_tif=paths['final_water'],
-                track_number=track_number
-                )
+        actual_burst_id = collect_burst_id(input_list,
+                                           DSWX_NI_POL_DICT['CO_POL'])
+        # In the case that mgrs_tile_collection_id is given
+        # from input, then extract the MGRS list from database
+        if input_mgrs_collection_id is not None:
+            mgrs_tile_list, most_overlapped = \
+                get_mgrs_tiles_list_from_db(
+                    mgrs_collection_file=mgrs_collection_db_path,
+                    mgrs_tile_collection_id=input_mgrs_collection_id)
+        # In the case that mgrs_tile_collection_id is not given
+        # from input, then extract the MGRS list from database
+        # using track number and area intersecting with image_tif
+        else:
+            mgrs_tile_list, most_overlapped = \
+                get_intersecting_mgrs_tiles_list_from_db(
+                    mgrs_collection_file=mgrs_collection_db_path,
+                    image_tif=paths['final_water'],
+                    track_number=track_number
+                    )
         maximum_frame = most_overlapped['number_of_frames']
         # convert string to list
         expected_frame_list = ast.literal_eval(most_overlapped['frames'])
@@ -760,13 +800,13 @@ def run(cfg):
         actual_frame_id = collect_burst_id(input_list,
                                            DSWX_NI_POL_DICT['CO_POL'])
         number_frame = len(actual_frame_id)
-        mgrs_meta_dict['MGRS_COLLECTION_EXPECTED_NUMBER_OF_BURSTS'] = \
+        mgrs_meta_dict['MGRS_COLLECTION_EXPECTED_NUMBER_OF_FRAMES'] = \
             maximum_frame
-        mgrs_meta_dict['MGRS_COLLECTION_ACTUAL_NUMBER_OF_BURSTS'] = \
+        mgrs_meta_dict['MGRS_COLLECTION_ACTUAL_NUMBER_OF_FRAMES'] = \
             number_frame
         missing_frame = len(list(set(expected_frame_list) -
                                  set(actual_frame_id)))
-        mgrs_meta_dict['MGRS_COLLECTION_MISSING_NUMBER_OF_BURSTS'] = \
+        mgrs_meta_dict['MGRS_COLLECTION_MISSING_NUMBER_OF_FRAMES'] = \
             missing_frame
         mgrs_meta_dict['MGRS_POL_MODE'] = pol_mode
     else:

--- a/src/dswx_sar/save_mgrs_tiles_ni.py
+++ b/src/dswx_sar/save_mgrs_tiles_ni.py
@@ -28,7 +28,7 @@ from dswx_sar.dswx_ni_runconfig import (RunConfig,
                                         get_pol_rtc_hdf5,
                                         DSWX_NI_POL_DICT)
 from dswx_sar.metadata import (create_dswx_ni_metadata,
-                               collect_burst_id,
+                               collect_frame_id,
                                _populate_statics_metadata_datasets)
 from dswx_sar.save_mgrs_tiles import (
     get_bounding_box_from_mgrs_tile,
@@ -774,8 +774,7 @@ def run(cfg):
     mgrs_meta_dict = {}
 
     if database_bool:
-        actual_burst_id = collect_burst_id(input_list,
-                                           DSWX_NI_POL_DICT['CO_POL'])
+        actual_frame_id = collect_frame_id(input_list)
         # In the case that mgrs_tile_collection_id is given
         # from input, then extract the MGRS list from database
         if input_mgrs_collection_id is not None:
@@ -797,8 +796,6 @@ def run(cfg):
         # convert string to list
         expected_frame_list = ast.literal_eval(most_overlapped['frames'])
         logger.info(f"Input RTCs are within {most_overlapped['mgrs_set_id']}")
-        actual_frame_id = collect_burst_id(input_list,
-                                           DSWX_NI_POL_DICT['CO_POL'])
         number_frame = len(actual_frame_id)
         mgrs_meta_dict['MGRS_COLLECTION_EXPECTED_NUMBER_OF_FRAMES'] = \
             maximum_frame


### PR DESCRIPTION
This PR allows to run the DSWx-NI algorithm with the given MGRS tile collection ID. 
In the previous version, the DSWx-NI still uses the method to find the MGRS tile collection ID by comparing image to the database in overlapped area and track number. However, this arises the issue in the antimeridian area, and equation regions in DSWx-S1 SAS. This PR fixes the issue that occurred in DSWx-S1. 