### PR TITLE
Search MGRS with bounding box only. 

### DIFF
--- a/build_docker_ni.sh
+++ b/build_docker_ni.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 IMAGE=opera/dswx-ni
-tag=beta_0.2
+tag=beta_0.2.1
 echo "IMAGE is $IMAGE:$tag"
 
 # fail on any non-zero exit codes

--- a/docker/Dockerfile_ni
+++ b/docker/Dockerfile_ni
@@ -1,8 +1,8 @@
 FROM oraclelinux:8
 
 LABEL author="OPERA ADT" \
-    description="DSWX-SAR Beta release R2" \
-    version="0.2-beta"
+    description="DSWX-SAR Beta patch release R2.1" \
+    version="0.2.1-beta"
 
 RUN yum -y update &&\
     yum -y install curl &&\

--- a/src/dswx_sar/save_mgrs_tiles_ni.py
+++ b/src/dswx_sar/save_mgrs_tiles_ni.py
@@ -252,7 +252,7 @@ def get_intersecting_mgrs_tiles_list_from_db(
 
     # If track number is given, then search MGRS tile collection with
     # track number
-    if track_number is not None:
+    if track_number is not None and track_number != 0:
         vector_gdf = vector_gdf[
             vector_gdf['track_number'] ==
             track_number].to_crs("EPSG:4326")
@@ -778,6 +778,7 @@ def run(cfg):
         # In the case that mgrs_tile_collection_id is given
         # from input, then extract the MGRS list from database
         if input_mgrs_collection_id is not None:
+            logger.info(f'input mgrs collection id {input_mgrs_collection_id} is provided.')
             mgrs_tile_list, most_overlapped = \
                 get_mgrs_tiles_list_from_db(
                     mgrs_collection_file=mgrs_collection_db_path,
@@ -786,6 +787,7 @@ def run(cfg):
         # from input, then extract the MGRS list from database
         # using track number and area intersecting with image_tif
         else:
+            logger.info(f'Searching MGRS tiles using bounding box.')
             mgrs_tile_list, most_overlapped = \
                 get_intersecting_mgrs_tiles_list_from_db(
                     mgrs_collection_file=mgrs_collection_db_path,

--- a/src/dswx_sar/version_ni.py
+++ b/src/dswx_sar/version_ni.py
@@ -1,1 +1,1 @@
-VERSION = '0.2'
+VERSION = '0.2.1'


### PR DESCRIPTION
This PR modifies the function searching MGRS tile. 

In current software, the MGRS tiles are found from two methodologies. 

1.  Using `input_mgrs_tile_id`
2. Using `bounding box` and `track number`
However, the sample ALOS GCOV products do not follow the NISAR track frame convention, and they don't have the correct frame and track number. This causes the crash in finding MGRS tiles. 

Thus, when the `track_number` is zero, the second method searches the MGRS tile using only bounding box. 