### PR TITLE
Fix metadata & change default channel

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,13 +1,24 @@
-gdal>=3.0
-numpy
-python>=3.6
-ruamel.yaml
-scipy
-pytest
-requests
-numpy
-h5py
-matplotlib
-scikit-image
-pyproj
-opencv
+name: dswx-sar
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:
+  - gdal>=3.0
+  - numpy
+  - python>=3.6
+  - ruamel.yaml
+  - scipy
+  - pytest
+  - requests
+  - numpy
+  - h5py
+  - matplotlib
+  - scikit-image
+  - pyproj
+  - opencv
+  - rasterio
+  - yamale
+  - mgrs
+  - rasterio
+  - geopandas
+  - shapely

--- a/docker/requirements_forge.txt
+++ b/docker/requirements_forge.txt
@@ -1,6 +1,0 @@
-rasterio
-yamale
-mgrs
-rasterio
-geopandas
-shapely

--- a/src/dswx_sar/metadata.py
+++ b/src/dswx_sar/metadata.py
@@ -383,7 +383,7 @@ def set_dswx_s1_metadata(metadata_dict):
     metadata_dict.update({
         'PRODUCT_TYPE': 'DSWx-S1',
         'PRODUCT_SOURCE': 'OPERA_RTC_S1',
-        'SPACECRAFT_NAME': 'Sentinel-1A/B',
+        'SPACECRAFT_NAME': 'Sentinel-1',
         'SENSOR': 'IW'
     })
 


### PR DESCRIPTION
This PR replaces the requirement.txt file so that only conda-forge libraries should be downloaded.
In addition, the metadata field addressing the SPACECRAFT is corrected.