### PR TITLE
Crop geogrid before mosaicking

### DIFF
--- a/src/dswx_sar/common/_dswx_geogrid.py
+++ b/src/dswx_sar/common/_dswx_geogrid.py
@@ -1,6 +1,7 @@
 
 from dataclasses import dataclass
-
+from typing import Optional, Tuple
+import math
 import numpy as np
 from osgeo import osr, gdal
 
@@ -102,45 +103,194 @@ class DSWXGeogrid:
         return cls(start_x, start_y, end_x, end_y, spacing_x, spacing_y,
                    length, width, epsg)
 
-    def update_geogrid(self, geotiff_path):
+    def update_geogrid(self, geotiff_path: str) -> None:
         """
-        Update the existing geographical grid parameters based on a new
-        GeoTIFF file, extending the grid to encompass both the existing
-        and new grid areas.
+        Update this geogrid to be the union of itself and the geogrid from geotiff_path.
+        Works for both north-up rasters (spacing_y < 0) and south-up (spacing_y > 0).
+
+        Conventions:
+        - We union using true bounds (xmin/xmax/ymin/ymax) independent of sign.
+        - We keep this object's spacing sign if already set; otherwise adopt new's.
+        - start_x/start_y represent the "origin corner" implied by spacing signs:
+            * spacing_x > 0  => start_x is xmin
+            * spacing_x < 0  => start_x is xmax
+            * spacing_y < 0  => start_y is ymax (north-up)
+            * spacing_y > 0  => start_y is ymin (south-up)
         """
-        new_geogrid = DSWXGeogrid.from_geotiff(geotiff_path)
+        new = DSWXGeogrid.from_geotiff(geotiff_path)
 
-        if self.epsg != new_geogrid.epsg and not np.isnan(self.epsg):
-            raise ValueError("EPSG codes of the existing and "
-                             "new geogrids do not match.")
-        self.start_x = min(filter(lambda x: not np.isnan(x),
-                                  [self.start_x, new_geogrid.start_x]))
-        self.end_x = max(filter(lambda x: not np.isnan(x),
-                                [self.end_x, new_geogrid.end_x]))
+        # EPSG check
+        if (not np.isnan(self.epsg)) and int(self.epsg) != int(new.epsg):
+            raise ValueError(
+                f"EPSG codes do not match: existing={self.epsg}, new={new.epsg}"
+            )
 
-        if self.spacing_y > 0 or np.isnan(self.spacing_y):
-            self.end_y = max(filter(lambda x: not np.isnan(x),
-                                    [self.end_y, new_geogrid.end_y]))
-            self.start_y = min(filter(lambda x: not np.isnan(x),
-                                      [self.start_y, new_geogrid.start_y]))
+        # Decide spacings (magnitude + sign)
+        # If self spacing is unset, inherit from new; otherwise keep self.
+        if np.isnan(self.spacing_x):
+            self.spacing_x = new.spacing_x
+        if np.isnan(self.spacing_y):
+            self.spacing_y = new.spacing_y
+
+        # Helper: bounds independent of sign
+        def _bounds(g):
+            xmin = min(g.start_x, g.end_x)
+            xmax = max(g.start_x, g.end_x)
+            ymin = min(g.start_y, g.end_y)
+            ymax = max(g.start_y, g.end_y)
+            return xmin, ymin, xmax, ymax
+
+        # Union bounds (handle NaNs gracefully)
+        xmin0, ymin0, xmax0, ymax0 = _bounds(self) if not np.isnan(self.start_x) else (np.nan, np.nan, np.nan, np.nan)
+        xmin1, ymin1, xmax1, ymax1 = _bounds(new)
+
+        xs = [v for v in (xmin0, xmin1) if not np.isnan(v)]
+        ys = [v for v in (ymin0, ymin1) if not np.isnan(v)]
+        xe = [v for v in (xmax0, xmax1) if not np.isnan(v)]
+        ye = [v for v in (ymax0, ymax1) if not np.isnan(v)]
+
+        xmin_u = min(xs)
+        ymin_u = min(ys)
+        xmax_u = max(xe)
+        ymax_u = max(ye)
+
+        # Reconstruct start/end consistent with spacing sign convention
+        sx = self.spacing_x
+        sy = self.spacing_y
+
+        # X
+        if sx >= 0:
+            self.start_x = xmin_u
+            self.end_x   = xmax_u
         else:
-            self.start_y = max(filter(lambda x: not np.isnan(x),
-                                      [self.start_y, new_geogrid.start_y]))
-            self.end_y = min(filter(lambda x: not np.isnan(x),
-                                    [self.end_y, new_geogrid.end_y]))
+            self.start_x = xmax_u
+            self.end_x   = xmin_u
 
-        self.spacing_x = new_geogrid.spacing_x \
-            if not np.isnan(new_geogrid.spacing_x) else self.spacing_x
-        self.spacing_y = new_geogrid.spacing_y \
-            if not np.isnan(new_geogrid.spacing_y) else self.spacing_y
+        # Y
+        if sy < 0:  # north-up
+            self.start_y = ymax_u
+            self.end_y   = ymin_u
+        else:       # south-up or unusual
+            self.start_y = ymin_u
+            self.end_y   = ymax_u
 
-        if not np.isnan(self.start_x) and not np.isnan(self.end_x) and \
-           not np.isnan(self.spacing_x):
-            self.width = int((self.end_x - self.start_x) / self.spacing_x)
+        # width/length (ensure positive)
+        if not np.isnan(sx) and sx != 0:
+            self.width = int(round((self.end_x - self.start_x) / sx))
+            self.width = abs(self.width)
 
-        if not np.isnan(self.start_y) and not np.isnan(self.end_y) and \
-           not np.isnan(self.spacing_y):
-            self.length = int((self.end_y - self.start_y) / self.spacing_y)
+        if not np.isnan(sy) and sy != 0:
+            self.length = int(round((self.end_y - self.start_y) / sy))
+            self.length = abs(self.length)
 
-        self.epsg = new_geogrid.epsg \
-            if not np.isnan(new_geogrid.epsg) else self.epsg
+        # EPSG
+        if np.isnan(self.epsg):
+            self.epsg = new.epsg
+
+
+    @staticmethod
+    def _snap_bounds_to_spacing(
+        xmin: float, ymin: float, xmax: float, ymax: float,
+        spacing_x: float, spacing_y: float,
+    ) -> Tuple[float, float, float, float]:
+        """
+        Snap bounds to pixel grid so width/length become integers.
+        Uses spacing magnitude; preserves original spacing sign when writing geogrid.
+        """
+        sx = abs(spacing_x)
+        sy = abs(spacing_y)
+        if sx == 0 or sy == 0 or math.isnan(sx) or math.isnan(sy):
+            raise ValueError("Invalid spacing for snapping bounds.")
+
+        # snap outward (cover the requested bbox)
+        xmin_s = math.floor(xmin / sx) * sx
+        ymin_s = math.floor(ymin / sy) * sy
+        xmax_s = math.ceil(xmax / sx) * sx
+        ymax_s = math.ceil(ymax / sy) * sy
+        return xmin_s, ymin_s, xmax_s, ymax_s
+
+    def clip_to_bbox(
+        self,
+        bbox: Tuple[float, float, float, float],
+        bbox_epsg: Optional[int] = None,
+        snap: bool = True,
+        snap_outward: bool = True,  # keep outward snap as default
+    ) -> None:
+        """
+        Intersect current geogrid with bbox (must be in same epsg).
+        Updates start/end/width/length to the intersection.
+        """
+        xmin_b, ymin_b, xmax_b, ymax_b = bbox
+
+        epsg_ok = not (self.epsg is None or (isinstance(self.epsg, float) and np.isnan(self.epsg)))
+        if bbox_epsg is not None and epsg_ok and int(self.epsg) != int(bbox_epsg):
+            raise ValueError(f"EPSG mismatch: geogrid epsg={self.epsg}, bbox epsg={bbox_epsg}. "
+                             "Reproject bbox first or force EPSG earlier.")
+
+        xmin_g, ymin_g, xmax_g, ymax_g = self.bounds()
+
+        ixmin = max(xmin_g, xmin_b)
+        iymin = max(ymin_g, ymin_b)
+        ixmax = min(xmax_g, xmax_b)
+        iymax = min(ymax_g, ymax_b)
+
+        if ixmin >= ixmax or iymin >= iymax:
+            if ixmin >= ixmax:
+                print('error x', ixmin, ixmax)
+            if iymin >= iymax:
+                print('error y', iymin, iymax)
+            raise ValueError("DB bbox does not intersect the data extent (geogrid).")
+
+        if snap:
+            # snap outward so you don't accidentally clip requested area by <1 pixel
+            ixmin, iymin, ixmax, iymax = self._snap_bounds_to_spacing(
+                ixmin, iymin, ixmax, iymax, self.spacing_x, self.spacing_y
+            )
+
+        # Re-apply sign convention used in your geogrid:
+        # spacing_x typically +, spacing_y may be negative.
+        sx = self.spacing_x
+        sy = self.spacing_y
+
+        # start_x should be left edge
+        self.start_x = ixmin
+        self.end_x = ixmax
+
+        # start_y should match your spacing_y sign convention:
+        # If sy < 0, start_y is the TOP (max y). If sy > 0, start_y is BOTTOM (min y).
+        if sy < 0:
+            self.start_y = iymax
+            self.end_y = iymin
+        else:
+            self.start_y = iymin
+            self.end_y = iymax
+
+        self.width  = int(round((self.end_x - self.start_x) / self.spacing_x)) if sx != 0 else self.width
+        self.length = int(round((self.end_y - self.start_y) / self.spacing_y)) if sy != 0 else self.length
+
+    def bounds(self) -> Tuple[float, float, float, float]:
+        """
+        Return geogrid bounds as (xmin, ymin, xmax, ymax) in the geogrid EPSG.
+        Works regardless of spacing_y sign (north-up geotiffs usually have spacing_y < 0).
+        """
+        # Ensure initialized
+        required = {
+            "start_x": self.start_x,
+            "start_y": self.start_y,
+            "end_x": self.end_x,
+            "end_y": self.end_y,
+            "spacing_x": self.spacing_x,
+            "spacing_y": self.spacing_y,
+        }
+        missing = [k for k, v in required.items() if v is None or (isinstance(v, float) and np.isnan(v))]
+        if missing:
+            raise RuntimeError(
+                f"Geogrid not initialized; missing {missing}. "
+                "Call update_geogrid()/from_geotiff() before clip_to_bbox()."
+            )
+
+        xmin = min(self.start_x, self.end_x)
+        xmax = max(self.start_x, self.end_x)
+        ymin = min(self.start_y, self.end_y)
+        ymax = max(self.start_y, self.end_y)
+        return xmin, ymin, xmax, ymax

--- a/src/dswx_sar/common/_dswx_sar_util.py
+++ b/src/dswx_sar/common/_dswx_sar_util.py
@@ -928,6 +928,23 @@ def get_raster_block(raster_path, block_param):
             block_param.data_width,
             block_param.read_length)
 
+        if data_block is None:
+            raise RuntimeError(f"ReadAsArray returned None for {raster_path=}, "
+                            f"{block_param.read_start_line=}, {block_param.data_width=}, {block_param.read_length=}")
+
+        try:
+            shp = data_block.shape
+            ndim = data_block.ndim
+        except Exception:
+            raise RuntimeError(f"Unexpected ReadAsArray return type: {type(data_block)}")
+
+        if ndim == 0:
+            raise RuntimeError(
+                f"ReadAsArray returned 0-D array for {raster_path=}, band={i+1}, "
+                f"{block_param.read_start_line=}, {block_param.data_width=}, {block_param.read_length=}, "
+                f"{block_param.block_pad=}. shape={shp}"
+            )
+
         # Pad data_block with zeros according to pad_length/pad_width
         data_block = np.pad(data_block, block_param.block_pad,
                             mode='constant', constant_values=0)
@@ -1802,27 +1819,31 @@ def _calculate_output_bounds(geotransform,
     list
         Adjusted bounding box coordinates [x_min, y_min, x_max, y_max].
     """
-    x_min = geotransform[0]
-    x_max = x_min + width * geotransform[1] 
+    gt0, gt1, gt2, gt3, gt4, gt5 = geotransform
 
-    if geotransform[5] < 0:
-        y_max = geotransform[3]
-        y_min = y_max + length * geotransform[5]
-    else:
-        y_min = geotransform[3]
-        y_max = y_min + length * geotransform[5]
+    # Corner coordinates derived from geotransform + raster size
+    # (no rotation assumed; if rotation exists, this needs a different approach)
+    x0 = gt0
+    y0 = gt3
+    x1 = gt0 + width  * gt1
+    y1 = gt3 + length * gt5
 
-    x_diff = x_max - x_min
-    y_diff = y_max - y_min
+    xmin = min(x0, x1)
+    xmax = max(x0, x1)
+    ymin = min(y0, y1)
+    ymax = max(y0, y1)
 
-    if x_diff % output_spacing != 0:
-        x_max = x_min + (x_diff // output_spacing + 1) * output_spacing
+    s = float(abs(output_spacing))
+    if not np.isfinite(s) or s <= 0:
+        raise ValueError(f"Invalid output_spacing: {output_spacing}")
 
-    output_spacing = -1 * np.abs(output_spacing)
-    if y_diff % output_spacing != 0:
-        y_min = y_max + (y_diff // np.abs(output_spacing) + 1) * output_spacing
+    # Snap outward so the bounds fully cover the original area
+    xmin_s = math.floor(xmin / s) * s
+    ymin_s = math.floor(ymin / s) * s
+    xmax_s = math.ceil (xmax / s) * s
+    ymax_s = math.ceil (ymax / s) * s
 
-    return [x_min, y_min, x_max, y_max]
+    return [xmin_s, ymin_s, xmax_s, ymax_s]
 
 
 def _perform_warp_in_memory(input_file,

--- a/src/dswx_sar/common/_filter_SAR.py
+++ b/src/dswx_sar/common/_filter_SAR.py
@@ -358,7 +358,6 @@ def tv_bregman(X: np.ndarray, **kwargs) -> np.ndarray:
     https://scikit-image.org/docs/stable/api/skimage.restoration.html#skimage.restoration.denoise_tv_bregman
     """
     lamb = kwargs.get('lambda_value', -1)
-    print('bregman', kwargs)
     X_db = np.log10(X, out=np.full(X.shape, np.nan), where=(~np.isnan(X)))
     X_db[np.isnan(X)] = -30
     X_db_dspkl = denoise_tv_bregman(X_db, weight=lamb)

--- a/src/dswx_sar/common/_metadata.py
+++ b/src/dswx_sar/common/_metadata.py
@@ -11,6 +11,7 @@ from dswx_sar.sentinel1.dswx_runconfig import DSWX_S1_POL_DICT
 from dswx_sar.common._dswx_sar_util import (band_assign_value_dict,
                                            read_geotiff)
 from dswx_sar.common.gcov_reader import RTCReader
+from dswx_sar.common.read_h5_s3 import open_h5
 
 # Constants
 UNKNOWN = 'UNKNOWN'
@@ -511,7 +512,7 @@ def collect_frame_id(h5_list):
     frame_id_list = []
     frame_path = '/science/LSAR/identification/frameNumber'
     for rtc_file in h5_list:
-        with h5py.File(rtc_file) as src:
+        with open_h5(rtc_file) as src:
             frame = src[frame_path][()]
             frame_id_list.append(frame)
     return list(set(frame_id_list))
@@ -541,33 +542,40 @@ def count_rfi_frames(h5_list, pol_list, rfi_likelihood_thresh):
     num_frames_rfi = 0
 
     for input_idx, rtc_file in enumerate(h5_list):
-        with h5py.File(rtc_file) as src:
+        rfi_found_in_frame = False
+
+        with open_h5(rtc_file) as src:
+            if freq_path_list not in src:
+                # if listOfFrequencies missing, we can't evaluate; skip this file
+                continue
             freq_group_list = src[freq_path_list][()]
 
             for freq_idx, freq_group in enumerate(freq_group_list):
-                freq_group = freq_group.decode('utf-8')
+                freq_group = freq_group.decode('utf-8') if isinstance(freq_group, (bytes, np.bytes_)) else str(freq_group)
 
                 for pol_idx, pol in enumerate(pol_list):
                     rfi_likelihood_path = (
                         f'/science/LSAR/GCOV/metadata/calibrationInformation/'
                         f'frequency{freq_group}/{pol}/rfiLikelihood'
                     )
+                    if rfi_likelihood_path not in src:
+                        continue
+
                     # make threshold a configurable
-                    if rfi_likelihood_path in src:
-                        rfi_likelihood = src[rfi_likelihood_path][()]
-                        if not np.isnan(rfi_likelihood) and rfi_likelihood > rfi_likelihood_thresh:
-                            rfi_found = True
-                            break
-                        else:
-                            rfi_found = False
-                            num_frames_rfi = None
-                    else:
-                        rfi_found = False
-                        num_frames_rfi = None
-                if rfi_found:
-                    num_frames_rfi += 1
+                    rfi_likelihood = src[rfi_likelihood_path][()]
+                    rfi_likelihood = float(np.asarray(rfi_likelihood))
+
+                    if np.isfinite(rfi_likelihood) and rfi_likelihood > rfi_likelihood_thresh:
+                        rfi_found_in_frame = True
+                        break
+
+                if rfi_found_in_frame:
                     break
 
+                if rfi_found_in_frame:
+                    break
+        if rfi_found_in_frame:
+            num_frames_rfi += 1
     return num_frames_rfi
 
 def create_dswx_s1_metadata(cfg,

--- a/src/dswx_sar/common/_mosaic.py
+++ b/src/dswx_sar/common/_mosaic.py
@@ -172,10 +172,13 @@ def requires_reprojection(geogrid_mosaic,
         # check spacing
         if dx != geogrid_mosaic.spacing_x:
             flag_requires_reprojection = True
+            print(f"dx {dx} != geogrid_mosaic.spacing_x {geogrid_mosaic.spacing_x}" )
             return flag_requires_reprojection
 
         if dy != geogrid_mosaic.spacing_y:
             flag_requires_reprojection = True
+            print('dy != geogrid_mosaic.spacing_y')
+            print(dy, geogrid_mosaic.spacing_y)
             return flag_requires_reprojection
 
         # check projection
@@ -185,17 +188,22 @@ def requires_reprojection(geogrid_mosaic,
 
             if epsg_raster != epsg_mosaic:
                 flag_requires_reprojection = True
+                print(f"epsg_raster {epsg_raster} != epsg_mosaic {epsg_mosaic}")
+
                 return flag_requires_reprojection
 
         # check the coordinates
         if (abs((x0 - geogrid_mosaic.start_x) % geogrid_mosaic.spacing_x) >
                 maxerr_coord):
             flag_requires_reprojection = True
+            print(f"{x0-geogrid_mosaic.start_x} is not multiple of spacing")
             return flag_requires_reprojection
 
         if (abs((y0 - geogrid_mosaic.start_y) % geogrid_mosaic.spacing_y) >
                 maxerr_coord):
             flag_requires_reprojection = True
+            print(f"{y0-geogrid_mosaic.start_y} is not multiple of spacing")
+
             return flag_requires_reprojection
 
     flag_requires_reprojection = False
@@ -231,6 +239,31 @@ def _compute_distance_to_burst_center(image, geotransform):
                        (dx * (x_distance_image - center_of_mass[1])) ** 2)
 
     return distance
+
+
+def _overlap_slices(offset_x, offset_y, src_h, src_w, mos_h, mos_w):
+    """
+    Compute paired slices for placing a src array into a mosaic array.
+    offset_* are src upper-left pixel indices in mosaic coordinates.
+    Returns (mos_y, mos_x, src_y, src_x) slices, or None if no overlap.
+    """
+    # Mosaic window (destination) in mosaic coords
+    x0_m = max(offset_x, 0)
+    y0_m = max(offset_y, 0)
+    x1_m = min(offset_x + src_w, mos_w)
+    y1_m = min(offset_y + src_h, mos_h)
+
+    if x0_m >= x1_m or y0_m >= y1_m:
+        return None
+
+    # Corresponding source window
+    x0_s = x0_m - offset_x
+    y0_s = y0_m - offset_y
+    x1_s = x1_m - offset_x
+    y1_s = y1_m - offset_y
+
+    return (slice(y0_m, y1_m), slice(x0_m, x1_m),
+            slice(y0_s, y1_s), slice(x0_s, x1_s))
 
 
 def compute_mosaic_array(list_rtc_images,
@@ -449,8 +482,10 @@ def compute_mosaic_array(list_rtc_images,
                     dstNodata=np.nan)
                 path_nlooks = relocated_file_nlooks
 
-            offset_imgx = 0
-            offset_imgy = 0
+            offset_imgx = int((list_geo_transform[i, 0] - xmin_mosaic) /
+                              posting_x + 0.5)
+            offset_imgy = int((list_geo_transform[i, 3] - ymax_mosaic) /
+                              posting_y + 0.5)
         else:
 
             # calculate the burst RTC's offset wrt. the output mosaic in
@@ -479,38 +514,41 @@ def compute_mosaic_array(list_rtc_images,
             band_ds = rtc_image_gdal_ds.GetRasterBand(i_band + 1)
             arr_rtc = band_ds.ReadAsArray()
 
-            if i_band == 0:
-                length = min(arr_rtc.shape[0], dim_mosaic[0] - offset_imgy)
-                width = min(arr_rtc.shape[1], dim_mosaic[1] - offset_imgx)
+            src_h, src_w = arr_rtc.shape
+            ol = _overlap_slices(offset_imgx,
+                                 offset_imgy,
+                                 src_h, src_w,
+                                 dim_mosaic[0],
+                                 dim_mosaic[1])
+            if ol is None:
+                continue  # this raster doesn't overlap mosaic at all
 
-            if (length != arr_rtc.shape[0] or
-                    width != arr_rtc.shape[1]):
-                # Image needs to be cropped to fit in the mosaic
-                arr_rtc = arr_rtc[0:length, 0:width]
+            mos_y, mos_x, src_y, src_x = ol
+            arr_rtc = arr_rtc[src_y, src_x]
 
             if mosaic_mode.lower() == 'average':
                 # Replace NaN values with 0
                 arr_rtc[np.isnan(arr_rtc)] = 0.0
 
                 arr_numerator[i_band,
-                              offset_imgy: offset_imgy + length,
-                              offset_imgx: offset_imgx + width] += \
+                              mos_y,
+                              mos_x] += \
                     arr_rtc * arr_nlooks
 
                 if path_nlooks is not None:
                     arr_denominator[
-                        offset_imgy: offset_imgy + length,
-                        offset_imgx: offset_imgx + width] += arr_nlooks
+                        mos_y,
+                        mos_x] += arr_nlooks
                 else:
                     arr_denominator[
-                        offset_imgy: offset_imgy + length,
-                        offset_imgx: offset_imgx + width] += np.asarray(
+                        mos_y,
+                        mos_x] += np.asarray(
                         arr_rtc > 0, dtype=np.byte)
 
                 continue
 
-            arr_temp = arr_numerator[i_band, offset_imgy: offset_imgy + length,
-                                     offset_imgx: offset_imgx + width].copy()
+            arr_temp = arr_numerator[i_band, mos_y,
+                                     mos_x].copy()
             if not np.isnan(no_data_value):
                 arr_temp[arr_temp == no_data_value] = np.nan
 
@@ -523,22 +561,22 @@ def compute_mosaic_array(list_rtc_images,
                     arr_rtc, geotransform)
 
                 arr_distance_temp = arr_distance[
-                    offset_imgy: offset_imgy + length,
-                    offset_imgx: offset_imgx + width]
+                    mos_y,
+                    mos_x]
                 ind = np.logical_or(np.isnan(arr_distance_temp),
                                     arr_new_distance <= arr_distance_temp)
 
                 arr_distance_temp[ind] = arr_new_distance[ind]
                 arr_distance[
-                    offset_imgy: offset_imgy + length,
-                    offset_imgx: offset_imgx + width] = arr_distance_temp
+                    mos_y,
+                    mos_x] = arr_distance_temp
 
                 del arr_distance_temp
 
             arr_temp[ind] = arr_rtc[ind]
             arr_numerator[i_band,
-                          offset_imgy: offset_imgy + length,
-                          offset_imgx: offset_imgx + width] = arr_temp
+                          mos_y,
+                          mos_x] = arr_temp
 
         rtc_image_gdal_ds = None
         nlooks_gdal_ds = None

--- a/src/dswx_sar/common/gcov_reader.py
+++ b/src/dswx_sar/common/gcov_reader.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import os
 import logging
 import warnings
@@ -10,15 +9,16 @@ from typing import Any
 import math
 import mimetypes
 
-import numpy as np
 import h5py
-from osgeo import gdal
+from h5py import Dataset
+import numpy as np
+from osgeo import gdal, osr
+from pyproj import Transformer
 import rasterio
 from rasterio.transform import Affine
 from rasterio.windows import Window
 
 from dswx_sar.common._mosaic import mosaic_single_output_file
-
 from dswx_sar.common._dswx_sar_util import (
     _aggregate_10m_to_30m_conv,
     _calculate_output_bounds,
@@ -36,6 +36,14 @@ from dswx_sar.common.read_h5_s3 import (
 )
 
 logger = logging.getLogger('dswx_sar')
+
+
+def reproject_bbox(bbox, src_epsg: int, dst_epsg: int):
+    xmin, ymin, xmax, ymax = bbox
+    tf = Transformer.from_crs(f"EPSG:{src_epsg}", f"EPSG:{dst_epsg}", always_xy=True)
+    x1, y1 = tf.transform(xmin, ymin)
+    x2, y2 = tf.transform(xmax, ymax)
+    return [min(x1, x2), min(y1, y2), max(x1, x2), max(y1, y2)]
 
 
 class DataReader(ABC):
@@ -67,6 +75,8 @@ class RTCReader(DataReader):
             resamp_method: str,
             resamp_out_res: float,
             resamp_required: bool,
+            bbox=None,
+            bbox_epsg=None
     ):
         """Read data from input HDF5s in blocks and generate mosaicked output
            Geotiff
@@ -99,7 +109,7 @@ class RTCReader(DataReader):
         flag_freq_equal, freq_list = check_rtc_frequency(input_list)
 
         num_input_files = len(input_list)
-        
+
         # Extract resolution information
         res_list, res_highest = get_rtc_spacing_list(input_list, freq_list)
 
@@ -109,21 +119,19 @@ class RTCReader(DataReader):
         # Remove dataset from processing based on minimum image resolution/posting
         for input_idx, input_rtc in enumerate(input_list):
             for freq_idx, freq_group in enumerate(freq_list[input_idx]):
-                print('freq', freq_group)
+
                 if res_list[input_idx][freq_idx] is not None and \
                     res_list[input_idx][freq_idx] > mosaic_posting_thresh:
 
                         del data_path[input_rtc][freq_group]
                 # if freq_group == 'B':
                 #     del data_path[input_rtc][freq_group]
-        print(data_path)
+
         # Generate layover mask path
         layover_mask_name = 'mask'
         layover_path = str(self.generate_nisar_layover_name(layover_mask_name))
 
         mask_path = self.generate_nisar_mask_name()
-
-        # Collect EPSG
         epsg_array, epsg_same_flag = self.get_nisar_epsg(input_list)
 
         # Write all RTC HDF5 inputs to intermeidate Geotiff first and re-use
@@ -139,6 +147,8 @@ class RTCReader(DataReader):
                 epsg_array,
                 data_path,
                 mask_path,
+                bbox=bbox,
+                bbox_epsg=bbox_epsg,
             )
 
         # To Do: Use flag_mosaic_freq_a and flag_mosaic_freq_b flags to
@@ -146,6 +156,7 @@ class RTCReader(DataReader):
 
         # Choose Resampling methods
         if resamp_required:
+            resampled_geogrid_in = DSWXGeogrid()
             # Apply multi-look technique
             if resamp_method == 'multilook':
                 if len(input_gtiff_list) > 0:
@@ -154,8 +165,9 @@ class RTCReader(DataReader):
                             input_geotiff,
                             scratch_dir,
                             resamp_out_res,
-                            geogrid_in,
+                            resampled_geogrid_in,
                         )
+
             else:
                 # Apply resampling using GDAL.Warp() based on
                 # resampling methods
@@ -165,7 +177,7 @@ class RTCReader(DataReader):
                             input_geotiff,
                             scratch_dir,
                             resamp_out_res,
-                            geogrid_in,
+                            resampled_geogrid_in,
                             resamp_method,
                             )
             if len(mask_gtiff_list) > 0:
@@ -175,16 +187,39 @@ class RTCReader(DataReader):
                         layover_geotiff,
                         scratch_dir,
                         resamp_out_res,
-                        geogrid_in,
+                        resampled_geogrid_in,
                         'nearest',
                         )
             else:
                 layover_exist = False
+
+            if bbox is not None:
+                # bbox is (xmin, ymin, xmax, ymax) in bbox_epsg
+                if bbox_epsg is None:
+                    raise ValueError("bbox was provided but bbox_epsg is None")
+
+                target_epsg = int(getattr(geogrid_in, "epsg", None))
+
+                # Reproject bbox to target_epsg if needed
+                if int(bbox_epsg) != target_epsg:
+                    bbox_use = reproject_bbox(bbox, int(bbox_epsg), target_epsg)
+                else:
+                    bbox_use = bbox
+                # Ensure geogrid EPSG matches target_epsg
+                ge_epsg = getattr(resampled_geogrid_in, "epsg", None)
+                if ge_epsg is None or int(ge_epsg) != target_epsg:
+                    resampled_geogrid_in.epsg = target_epsg
+                # Now bbox_use is in target_epsg, so pass bbox_epsg=target_epsg
+                resampled_geogrid_in.clip_to_bbox(bbox_use, bbox_epsg=target_epsg, snap=True)
+
+                bx = resampled_geogrid_in.bounds()
+                print(f"[BBox clip] final geogrid bounds: {bx}, epsg={geogrid_in.epsg}")
+            geogrid_in = resampled_geogrid_in
+
+        if len(mask_gtiff_list) > 0:
+            mask_exist = True
         else:
-            if len(mask_gtiff_list) > 0:
-                mask_exist = True
-            else:
-                mask_exist = True
+            mask_exist = True
 
         # Mosaic intermediate geotiffs
         nlooks_list = []
@@ -206,6 +241,8 @@ class RTCReader(DataReader):
             epsg_array: np.ndarray,
             data_path: dict,
             mask_path: list,
+            bbox=None,
+            bbox_epsg=None
     ):
         """ Create intermediate Geotiffs from a list of input RTCs
 
@@ -380,6 +417,30 @@ class RTCReader(DataReader):
 
             geogrid_in.update_geogrid(output_mask_gtiff)
 
+        # --- Apply DB bbox constraint AFTER geogrid union is built ---
+        if bbox is not None:
+            # bbox is (xmin, ymin, xmax, ymax) in bbox_epsg
+            if bbox_epsg is None:
+                raise ValueError("bbox was provided but bbox_epsg is None")
+
+            target_epsg = int(getattr(geogrid_in, "epsg", None))
+
+            # Reproject bbox to target_epsg if needed
+            if int(bbox_epsg) != target_epsg:
+                bbox_use = reproject_bbox(bbox, int(bbox_epsg), target_epsg)
+            else:
+                bbox_use = bbox
+            # Ensure geogrid EPSG matches target_epsg (after harmonization it should)
+            # If it doesn't, that's a bug earlier — but we can force it here safely.
+            ge_epsg = getattr(geogrid_in, "epsg", None)
+            if ge_epsg is None or int(ge_epsg) != target_epsg:
+                geogrid_in.epsg = target_epsg
+
+            # Now bbox_use is in target_epsg, so pass bbox_epsg=target_epsg
+            geogrid_in.clip_to_bbox(bbox_use, bbox_epsg=target_epsg, snap=True)
+
+            bx = geogrid_in.bounds()
+            logger.info(f"[BBox clip] final geogrid bounds: {bx}, epsg={geogrid_in.epsg}")
         return geogrid_in, output_gtiff_list, mask_gtiff_list, pol_gtiff_list
 
     def read_write_rtc_h5py(
@@ -430,15 +491,13 @@ class RTCReader(DataReader):
                 yield slice(r, min(r + blk, n_rows))
                 r += blk
 
-        print(output_gtiff)
         chunk = h5_dset.chunks or (512, 512)  # fallback if unchunked
         chunk_rows = chunk[0]
-        print(chunk, chunk_rows)
         # Read K chunk-rows at a time (tune K by RAM; 4–16 is a good start)
         K = 8
         row_blk_size = K * chunk_rows
         col_blk_size = num_cols  # full width stripes
-    
+
         with rasterio.open(output_gtiff, 'w', **profile) as dst:
             # for slice_row in slice_gen(num_rows, row_blk_size):
             for s in aligned_ranges(num_rows, row_blk_size, chunk_rows):
@@ -446,7 +505,7 @@ class RTCReader(DataReader):
                 # rs = slice_row.start
                 # re = slice_row.stop
                 rs, re = s.start, s.stop
-                print(rs, re)
+
                 # for slice_col in slice_gen(num_cols, col_blk_size):
                 #     cs = slice_col.start
                 #     ce = slice_col.stop
@@ -628,7 +687,8 @@ class RTCReader(DataReader):
 
         input_res_x = np.abs(geotransform_input[1])
         input_res_y = np.abs(geotransform_input[5])
-
+        xsign = 1.0 if geotransform_input[1] >= 0 else -1.0
+        ysign = 1.0 if geotransform_input[5] >= 0 else -1.0
         if input_res_x != input_res_y:
             raise ValueError(
                 "x and y resolutions of the input must be the same."
@@ -654,8 +714,8 @@ class RTCReader(DataReader):
 
             # Perform GDAL.warp() in memory for upsampled data
             warp_options = gdal.WarpOptions(
-                xRes=interm_upsamp_res,
-                yRes=-interm_upsamp_res,
+                xRes=xsign * interm_upsamp_res,
+                yRes=ysign * interm_upsamp_res,
                 outputBounds=upsamp_bounds,
                 resampleAlg='nearest',
                 format='MEM'  # Use memory as the output format
@@ -712,62 +772,80 @@ class RTCReader(DataReader):
     def write_array_to_geotiff(
         self,
         ds_input,
-        output_data,
-        output_bounds,
-        output_res,
-        output_geotiff,
+        output_data: np.ndarray,
+        output_bounds,   # [xmin, ymin, xmax, ymax] or None
+        output_res: float,
+        output_geotiff: str,
+        *,
+        nodata=None,
+        compress="DEFLATE",
+        predictor=2,
     ):
-        """Create output geotiff using gdal.CreateCopy()
-
-        Parameters
-        ----------
-        ds_input: gdal dataset
-            input dataset opened by GDAL
-        output_data: numpy.ndarray
-            output_data to be written into output geotiff
-        output_bounds: list
-            The bounding box coordinates where the output will be clipped.
-        output_res: float
-            User define output resolution for resampled Geotiff
-        downsamp_ratio: int
-            downsampling factor for dataset in the input geotiff
-        output_geotiff: str
-            Output geotiff to be created.
         """
+        Write output_data to GeoTIFF with correct geotransform.
+        Keeps the sign of x/y pixel sizes from ds_input.
+        Assumes north-up (no rotation). If rotation exists, use gdal.Warp instead.
+        """
+        gt_in = ds_input.GetGeoTransform()
+        rot_x, rot_y = gt_in[2], gt_in[4]
+        if rot_x != 0 or rot_y != 0:
+            raise ValueError("Input geotransform has rotation; use GDAL.Warp for correct georeferencing.")
 
-        # Update Geotransformation
-        geotransform_input = ds_input.GetGeoTransform()
-        geotransform_output = (
-            geotransform_input[0],
-            output_res,
-            geotransform_input[2],
-            geotransform_input[3],
-            geotransform_input[4],
-            output_res,
-        )
+        # Keep sign convention from input
+        xsign = 1.0 if gt_in[1] >= 0 else -1.0
+        ysign = 1.0 if gt_in[5] >= 0 else -1.0
+        px = xsign * float(output_res)
+        py = ysign * float(output_res)
 
-        # Calculate the output raster size
-        output_y_size, output_x_size = output_data.shape
+        # Normalize output_data shape to (bands, rows, cols)
+        arr = np.asarray(output_data)
+        if arr.ndim == 2:
+            arr = arr[None, :, :]
+        elif arr.ndim == 3:
+            pass
+        else:
+            raise ValueError(f"output_data must be 2D or 3D, got shape {arr.shape}")
 
-        driver = gdal.GetDriverByName('GTiff')
-        ds_output = driver.Create(
+        bands, rows, cols = arr.shape
+
+        # Decide origin: from bounds if provided, else from input origin
+        if output_bounds is not None:
+            xmin, ymin, xmax, ymax = output_bounds
+            # For north-up (py < 0): origin Y should be ymax
+            # For south-up (py > 0): origin Y should be ymin
+            origin_x = xmin
+            origin_y = ymax if py < 0 else ymin
+        else:
+            origin_x = gt_in[0]
+            origin_y = gt_in[3]
+
+        gt_out = (origin_x, px, 0.0, origin_y, 0.0, py)
+
+        creation_opts = [f"COMPRESS={compress}"]
+        if compress.upper() in ("DEFLATE", "LZW"):
+            creation_opts.append(f"PREDICTOR={predictor}")
+
+        driver = gdal.GetDriverByName("GTiff")
+        ds_out = driver.Create(
             output_geotiff,
-            output_x_size,
-            output_y_size,
-            ds_input.RasterCount,
-            gdal.GDT_Float32
+            cols,
+            rows,
+            bands,
+            gdal.GDT_Float32,
+            options=creation_opts,
         )
+        ds_out.SetGeoTransform(gt_out)
+        ds_out.SetProjection(ds_input.GetProjection())
 
-        # Set Geotransform and Projection
-        ds_output.SetGeoTransform(geotransform_output)
-        ds_output.SetProjection(ds_input.GetProjection())
+        if nodata is not None:
+            for b in range(1, bands + 1):
+                ds_out.GetRasterBand(b).SetNoDataValue(float(nodata))
 
-        # Write output data to raster
-        ds_output.GetRasterBand(1).WriteArray(output_data)
+        for b in range(bands):
+            ds_out.GetRasterBand(b + 1).WriteArray(arr[b])
 
-        ds_input = None
-        ds_output = None
-
+        ds_out.FlushCache()
+        ds_out = None
 
     def extract_file_name(self, input_rtc):
         """Extract file name identifier from input file name
@@ -867,7 +945,6 @@ class RTCReader(DataReader):
                 warnings.warn(f'\nFrequency group {freq_group} does not exist.'
                               , RuntimeWarning)
                 continue
-                    
 
         return h5_path_dict
 
@@ -1000,7 +1077,7 @@ class RTCReader(DataReader):
                     if is_mask:
                         # Keep 0/1 (or general categorical) as-is,
                         # map invalids to 255 if any
-                        # If the dataset has >1 values for "valid", 
+                        # If the dataset has >1 values for "valid",
                         # we leave them; caller can binarize upstream if needed.
                         ds_blk = ds_blk.astype(np.int32)  # safe cast before setting nodata
                         ds_blk = np.where(np.isfinite(ds_blk), ds_blk, 255)

--- a/src/dswx_sar/common/read_h5_s3.py
+++ b/src/dswx_sar/common/read_h5_s3.py
@@ -1,5 +1,4 @@
 # s3_h5_min.py
-from __future__ import annotations
 import os
 from typing import Optional, Tuple, Iterator
 from urllib.parse import urlparse
@@ -7,6 +6,7 @@ from urllib.parse import urlparse
 import boto3
 from botocore.config import Config as BotoConfig
 import h5py
+from contextlib import contextmanager
 
 
 def is_s3_path(path: str) -> bool:
@@ -213,3 +213,15 @@ def slice_gen(total_size: int, batch_size: int, combine_rem: bool = True) -> Ite
             yield slice(start, start + batch_size)
         if n_rem:
             yield slice(n_total_full, total_size)
+
+
+@contextmanager
+def open_h5(path: str):
+    # Use your ROS3-aware reader for s3/http; local uses h5py directly inside H5Reader too
+    with H5Reader(
+        path,
+        profile="saml-pub",
+        use_presign_fallback=False,  # set True if you want fallback
+        request_payer_requester=False,
+    ) as f:
+        yield f

--- a/src/dswx_sar/defaults/algorithm_parameter_ni.yaml
+++ b/src/dswx_sar/defaults/algorithm_parameter_ni.yaml
@@ -48,6 +48,7 @@ runconfig:
             #   - first : choose one burst without average.
             mosaic_mode: 'first'
             mosaic_posting_thresh: 40
+            mosaic_margin: 20
             resamp_required: True
             resamp_method: 'nearest'
             resamp_out_res: 30

--- a/src/dswx_sar/nisar/dswx_ni_runconfig.py
+++ b/src/dswx_sar/nisar/dswx_ni_runconfig.py
@@ -13,6 +13,7 @@ from ruamel.yaml import YAML
 
 import dswx_sar
 from dswx_sar.common._dswx_sar_util import check_gdal_raster_s3
+from dswx_sar.common.read_h5_s3 import open_h5, file_exists
 
 logger = logging.getLogger('dswx_sar')
 
@@ -196,11 +197,13 @@ def check_file_path(file_path: str) -> None:
     if file_path.startswith('/vsis3/'):
         check_gdal_raster_s3(file_path, raise_error=True)
 
-    else:
-        if not os.path.exists(file_path):
-            err_str = f'{file_path} not found'
-            logger.error(err_str)
-            raise FileNotFoundError(err_str)
+    if file_path.startswith('s3://'):
+        if not file_exists(file_path, profile="saml-pub"):
+            raise FileNotFoundError(f"{file_path} not found (S3 head_object failed)")
+        return
+
+    if not os.path.exists(file_path):
+        raise FileNotFoundError(f"{file_path} not found")
 
 
 def get_pol_rtc_hdf5(input_rtc, freq_group):
@@ -224,7 +227,7 @@ def get_pol_rtc_hdf5(input_rtc, freq_group):
     """
     path_pol = f'/science/LSAR/GCOV/grids/frequency{freq_group}/listOfPolarizations'
 
-    with h5py.File(input_rtc) as src:
+    with open_h5(input_rtc) as src:
         pols = src[path_pol][()]
         pols = [pol.decode('utf-8') for pol in pols]
 
@@ -246,7 +249,7 @@ def get_freq_rtc_hdf5(input_rtc):
     """
     path_freq = f'/science/LSAR/identification/listOfFrequencies'
 
-    with h5py.File(input_rtc) as src_h5:
+    with open_h5(input_rtc) as src_h5:
         freq_group_list = src_h5[path_freq][()]
         freq = [freq_group.decode('utf-8') for freq_group in freq_group_list]
     return freq
@@ -269,7 +272,7 @@ def get_x_spacing_rtc_hdf5(input_rtc, freq_group):
     """
     x_posting = f'/science/LSAR/GCOV/grids/frequency{freq_group}/xCoordinateSpacing'
 
-    with h5py.File(input_rtc, 'r') as src:
+    with open_h5(input_rtc) as src:
         res = src[x_posting][()]
 
     return res
@@ -685,11 +688,10 @@ def extract_bandwidth(input_dir_list):
 
     for input_idx, input_rtc in enumerate(input_dir_list):
         # Check if the file exists
-        if not os.path.exists(input_rtc):
-            raise FileNotFoundError(
-                f"The file '{input_rtc}' does not exist.")
+        if not file_exists(input_rtc, profile="saml-pub"):
+            raise FileNotFoundError(f"The file '{input_rtc}' does not exist or is not accessible.")
 
-        with h5py.File(input_rtc, 'r') as src_h5:
+        with open_h5(input_rtc) as src_h5:
             freq_group_list = src_h5[freq_path_list][()]
             freq_group_list = [freq_group.decode('utf-8') for freq_group in freq_group_list]
 
@@ -848,7 +850,7 @@ class RunConfig:
             flag_pol_freq_a_equal,
             flag_pol_freq_b_equal,
             freq_list,
-            res_freq_b_equal,
+            res_freq_a_equal,
             res_freq_b_equal,
             res_highest,
             nisar_uni_mode
@@ -860,9 +862,12 @@ class RunConfig:
 
         # Determine highest resolution in an RTC input
         res_list, res_highest = get_rtc_spacing_list(input_dir_list, freq_list)
-
-        algorithm_cfg[
-            'runconfig']['processing']['mosaic']['resamp_out_res'] = res_highest
+        resample_out_spacing =algorithm_cfg[
+                'runconfig']['processing']['mosaic']['resamp_out_res']
+        print(nisar_uni_mode, resample_out_spacing)
+        if not nisar_uni_mode:
+            algorithm_cfg[
+                'runconfig']['processing']['mosaic']['resamp_out_res'] = res_highest
 
         algorithm_sns = wrap_namespace(
             algorithm_cfg['runconfig']['processing'])

--- a/src/dswx_sar/nisar/mosaic_gcov_frame.py
+++ b/src/dswx_sar/nisar/mosaic_gcov_frame.py
@@ -3,7 +3,10 @@ import logging
 import time
 
 from collections.abc import Iterator
+from dataclasses import dataclass
+import geopandas as gpd
 import mimetypes
+from typing import Optional, Tuple
 
 from dswx_sar.common.gcov_reader import RTCReader
 from dswx_sar.nisar.dswx_ni_runconfig import (
@@ -12,6 +15,70 @@ from dswx_sar.nisar.dswx_ni_runconfig import (
 
 
 logger = logging.getLogger('dswx_sar')
+
+@dataclass(frozen=True)
+class BBox:
+    xmin: float
+    ymin: float
+    xmax: float
+    ymax: float
+
+    def expand(self, margin: float) -> "BBox":
+        if margin is None or margin == 0:
+            return self
+        return BBox(
+            xmin=self.xmin - margin,
+            ymin=self.ymin - margin,
+            xmax=self.xmax + margin,
+            ymax=self.ymax + margin,
+        )
+
+
+def _read_mgrs_set_bbox_and_epsg(
+    mgrs_collection_db: str,
+    mgrs_collection_id: str,
+    layer: str = "mgrs_track_frame_db",
+    id_col: str = "mgrs_set_id",
+    xmin_col: str = "xmin",
+    ymin_col: str = "ymin",
+    xmax_col: str = "xmax",
+    ymax_col: str = "ymax",
+    epsg_col: str = "epsg",
+) -> Tuple[BBox, Optional[int]]:
+    gdf = gpd.read_file(mgrs_collection_db, layer=layer)
+
+    if id_col not in gdf.columns:
+        raise KeyError(f"Column '{id_col}' not found in layer '{layer}'")
+
+    filtered = gdf[gdf[id_col] == mgrs_collection_id]
+    if filtered.empty:
+        raise ValueError(
+            f"No rows found for {id_col}='{mgrs_collection_id}' in layer '{layer}'"
+        )
+    if len(filtered) > 1:
+        # If duplicates exist, you can decide how to handle them.
+        # Here we take the first row deterministically.
+        filtered = filtered.iloc[[0]]
+
+    row = filtered.iloc[0]
+
+    for c in (xmin_col, ymin_col, xmax_col, ymax_col):
+        if c not in gdf.columns:
+            raise KeyError(f"Column '{c}' not found in layer '{layer}'")
+
+    bbox = BBox(
+        xmin=float(row[xmin_col]),
+        ymin=float(row[ymin_col]),
+        xmax=float(row[xmax_col]),
+        ymax=float(row[ymax_col]),
+    )
+
+    epsg_val = None
+    if epsg_col in gdf.columns:
+        v = row[epsg_col]
+        epsg_val = None if v is None else int(v)
+
+    return bbox, epsg_val
 
 
 def run(cfg):
@@ -34,17 +101,47 @@ def run(cfg):
     mosaic_mode = mosaic_cfg.mosaic_mode
     mosaic_prefix = mosaic_cfg.mosaic_prefix
     mosaic_posting_thresh = mosaic_cfg.mosaic_posting_thresh
-    nisar_uni_mode = processing_cfg.nisar_uni_mode
+    # input margin is km.
+    mosaic_margin = mosaic_cfg.mosaic_margin * 1000
 
+    nisar_uni_mode = processing_cfg.nisar_uni_mode
+    resamp_required = mosaic_cfg.resamp_required
     # Determine if resampling is required
-    if nisar_uni_mode:
-        resamp_required = False
-    else:
+    if not nisar_uni_mode:
         resamp_required = True
 
     resamp_method = mosaic_cfg.resamp_method
     resamp_out_res = mosaic_cfg.resamp_out_res
 
+    mgrs_collection_db = \
+        cfg.groups.static_ancillary_file_group.mgrs_collection_database_file
+    mgrs_collection_id = cfg.groups.input_file_group.input_mgrs_collection_id
+    mgrs_bbox = None
+    mgrs_epsg = None
+
+    if mgrs_collection_db is not None and mgrs_collection_id is not None:
+        bbox, epsg_val = _read_mgrs_set_bbox_and_epsg(
+            mgrs_collection_db=mgrs_collection_db,
+            mgrs_collection_id=mgrs_collection_id,
+            layer="mgrs_track_frame_db",
+            id_col="mgrs_set_id",
+            xmin_col="xmin",
+            ymin_col="ymin",
+            xmax_col="xmax",
+            ymax_col="ymax",
+            epsg_col="EPSG",  # change if your column name differs
+        )
+        bbox = bbox.expand(mosaic_margin)
+        mgrs_bbox = (bbox.xmin, bbox.ymin, bbox.xmax, bbox.ymax)
+        mgrs_epsg = epsg_val
+
+        logger.info(f"MGRS set id: {mgrs_collection_id}")
+        logger.info(f"MGRS bbox (expanded): {mgrs_bbox}")
+        logger.info(f"MGRS epsg: {mgrs_epsg}")
+
+    logger.info(f"Resampling : {resamp_required}")
+    logger.info(f"Resampling : {resamp_method}")
+    logger.info(f"Resampling : {resamp_out_res}")
     scratch_dir = cfg.groups.product_path_group.scratch_path
     os.makedirs(scratch_dir, exist_ok=True)
 
@@ -67,6 +164,8 @@ def run(cfg):
         resamp_method,
         resamp_out_res,
         resamp_required,
+        bbox=mgrs_bbox,      # (xmin, ymin, xmax, ymax) or None
+        bbox_epsg=mgrs_epsg, # int or None
     )
     t_all_elapsed = time.time() - t_all
     logger.info("successfully ran mosaic GCOV in "

--- a/src/dswx_sar/nisar/pre_processing.py
+++ b/src/dswx_sar/nisar/pre_processing.py
@@ -28,7 +28,7 @@ logger = logging.getLogger('dswx_sar')
 def run(cfg):
 
     logger.info("")
-    logger.info('Starting DSWx-S1 Preprocessing')
+    logger.info('Starting DSWx-NI Preprocessing')
 
     t_all = time.time()
     processing_cfg = cfg.groups.processing
@@ -308,7 +308,7 @@ def _filter_one_block(block_param,
         if mask_path is not None and mask_flag:
             mask_block = _dswx_sar_util.get_raster_block(
                 mask_path, block_param)
-            arr[mask_block != 1] = np.nan
+            arr[(mask_block == 0) | (mask_block == 255)] = np.nan
         arr[arr == 0] = np.nan         # mask padded zeros
         real_pol_data[pol] = arr.astype(np.float32)
 

--- a/src/dswx_sar/schemas/algorithm_parameter_ni.yaml
+++ b/src/dswx_sar/schemas/algorithm_parameter_ni.yaml
@@ -42,6 +42,7 @@ runconfig:
             mosaic_cog_enable: bool(required=False)
             mosaic_mode: str(required=False)
             mosaic_posting_thresh: num(required=False)
+            mosaic_margin: num(required=False)
             resamp_required: bool(required=False)
             resamp_method: str(required=False)
             resamp_out_res: num(required=False)


### PR DESCRIPTION
NISAR GCOV images cover much larger areas compared to Sentinel-1 bursts. When more than two GCOV frames are required to cover an MGRS collection area, we mosaicked them and produce water map for entire areas and make the product package at the final stage for target MGRS. Here, the unnecessary regions increase memory usage and slow down processing.

To address this limitation, this PR reads the bounding box from the MGRS collection database for the target MGRS collection ID and applies a margin to the bounding box. The bounding box is defined prior to mosaicking, and the images are mosaicked only within the defined area.