### PR TITLE
fix offset issue and make it faster by reading only required area

### DIFF
--- a/src/dswx_sar/common/_mosaic.py
+++ b/src/dswx_sar/common/_mosaic.py
@@ -321,7 +321,7 @@ def compute_mosaic_array(
     for i, path_rtc in enumerate(list_rtc_images):
         raster_in = gdal.Open(path_rtc, gdal.GA_ReadOnly)
         if raster_in is None:
-            raise runtimeerror(f"error: could not open rtc raster: {path_rtc}")
+            raise RuntimeError(f"error: could not open rtc raster: {path_rtc}")
 
         list_geo_transform[i, :] = raster_in.GetGeoTransform()
         list_dimension[i, :] = (raster_in.RasterYSize, raster_in.RasterXSize)
@@ -331,7 +331,7 @@ def compute_mosaic_array(
         if num_bands is None:
             num_bands = raster_in.RasterCount
         elif num_bands != raster_in.RasterCount:
-            raise valueerror(
+            raise ValueError(
                 f'error: the file "{os.path.basename(path_rtc)}" has {raster_in.RasterCount} bands. expected: {num_bands}.'
             )
 
@@ -483,9 +483,9 @@ def compute_mosaic_array(
                 )
                 path_nlooks = relocated_file_nlooks
 
-            offset_imgx = int((list_geo_transform[i, 0] - xmin_mosaic) /
+            offset_col = int((list_geo_transform[i, 0] - xmin_mosaic) /
                               posting_x + 0.5)
-            offset_imgy = int((list_geo_transform[i, 3] - ymax_mosaic) /
+            offset_row = int((list_geo_transform[i, 3] - ymax_mosaic) /
                               posting_y + 0.5)
         else:
             offset_col = int((list_geo_transform[i, 0] - xmin_mosaic) / posting_x + 0.5)
@@ -513,8 +513,9 @@ def compute_mosaic_array(
         gt = rtc_ds.GetGeoTransform()
         src_h = rtc_ds.RasterYSize
         src_w = rtc_ds.RasterXSize
-        offset_col = int((gt[0] - xmin_mosaic) / posting_x + 0.5)
-        offset_row = int((gt[3] - ymax_mosaic) / posting_y + 0.5)
+
+        offset_col = int(np.round((gt[0] - xmin_mosaic) / posting_x))
+        offset_row = int(np.round((gt[3] - ymax_mosaic) / posting_y))
         if verbose:
             print(f'        image offset (x, y): ({offset_col}, {offset_row})')
         # Compute overlap windows (destination + corresponding source window)

--- a/src/dswx_sar/common/gcov_reader.py
+++ b/src/dswx_sar/common/gcov_reader.py
@@ -52,6 +52,83 @@ def hwm_mib():
         return float("nan")
 
 
+def multi_look_average_gdal(
+    input_geotiff: str,
+    scratch_dir: str,
+    output_res: float,
+    geogrid_in
+):
+    """
+    Fast multi-look using gdal.Warp average resampling.
+    Supports inputs at 10m or 20m and produces output at output_res (e.g. 30).
+    Replaces the previous memory-heavy upsample + numpy aggregation.
+    """
+
+    # --- global GDAL tuning (set once per process ideally) ---
+    gdal.SetConfigOption("GDAL_NUM_THREADS", "ALL_CPUS")
+    # cache in MB (tune to available RAM)
+    gdal.SetConfigOption("GDAL_CACHEMAX", "2048")
+
+    ds_input = gdal.Open(input_geotiff, gdal.GA_ReadOnly)
+    if ds_input is None:
+        raise FileNotFoundError(f"Cannot open {input_geotiff}")
+
+    gt = ds_input.GetGeoTransform()
+    input_res_x = abs(gt[1])
+    input_res_y = abs(gt[5])  # typically negative; abs for magnitude
+
+    if input_res_x != input_res_y:
+        ds_input = None
+        raise ValueError("Input x/y resolutions mismatch: must be same")
+
+    if int(input_res_x) not in (10, 20):
+        ds_input = None
+        raise ValueError(f"Input resolution {input_res_x} not supported (expect 10 or 20)")
+
+    # Output filename
+    full_path = Path(input_geotiff)
+    output_geotiff = f'{full_path.parent}/{full_path.stem}_multi_look.tif'
+
+    # Determine srcNodata if present (prefer dataset value)
+    band = ds_input.GetRasterBand(1)
+    src_nodata = band.GetNoDataValue()
+    # If the dataset uses some designated_value sentinel (e.g. 500), you can set it explicitly:
+    # src_nodata = src_nodata if src_nodata is not None else 500
+
+    # WarpOptions: average resampling to output_res
+    warp_opts = gdal.WarpOptions(
+        format='GTiff',
+        xRes=float(output_res),
+        yRes=float(output_res),
+        resampleAlg='average',
+        multithread=True,
+        warpMemoryLimit=2048,            # MB, tune as necessary
+        srcNodata=src_nodata,
+        dstNodata=src_nodata,
+        targetAlignedPixels=True,
+        creationOptions=[
+            "TILED=YES",
+            "BLOCKXSIZE=512",
+            "BLOCKYSIZE=512",
+            "COMPRESS=DEFLATE",     # you may skip compression for scratch for speed
+            "PREDICTOR=2",
+            "BIGTIFF=IF_SAFER",
+        ],
+    )
+
+    # Run warp (this writes directly to disk, streaming & multi-threaded)
+    ds_out = gdal.Warp(output_geotiff, ds_input, options=warp_opts)
+    if ds_out is None:
+        ds_input = None
+        raise RuntimeError("gdal.Warp failed")
+
+    # Update the geogrid and replace original file
+    geogrid_in.update_geogrid(output_geotiff)
+    ds_out = None
+    ds_input = None
+    os.replace(output_geotiff, input_geotiff)
+
+
 def reproject_bbox(bbox, src_epsg: int, dst_epsg: int):
     xmin, ymin, xmax, ymax = bbox
     tf = Transformer.from_crs(f"EPSG:{src_epsg}", f"EPSG:{dst_epsg}", always_xy=True)
@@ -175,10 +252,7 @@ class RTCReader(DataReader):
                 bbox_epsg=bbox_epsg,
             )
 
-        if len(mask_gtiff_list) > 0:
-            mask_exist = True
-        else:
-            mask_exist = True
+        mask_exist = (len(mask_gtiff_list) > 0)
         # To Do: Use flag_mosaic_freq_a and flag_mosaic_freq_b flags to
         # filter frequency A or B from processing
 
@@ -189,7 +263,7 @@ class RTCReader(DataReader):
             if resamp_method == 'multilook':
                 if len(input_gtiff_list) > 0:
                     for idx, input_geotiff in enumerate(input_gtiff_list):
-                        self.multi_look_average(
+                        multi_look_average_gdal(
                             input_geotiff,
                             scratch_dir,
                             resamp_out_res,
@@ -254,49 +328,25 @@ class RTCReader(DataReader):
             mask_exist,
         )
 
-    # Class functions
+
     def write_rtc_geotiff(
-            self,
-            input_list: list,
-            scratch_dir: str,
-            epsg_array: np.ndarray,
-            data_path: dict,
-            mask_path: list,
-            gdal_cache_max_mb: int,
-            bbox=None,
-            bbox_epsg=None
+        self,
+        input_list: list,
+        scratch_dir: str,
+        epsg_array: np.ndarray,
+        data_path: dict,
+        mask_path: str,
+        gdal_cache_max_mb: int,
+        bbox=None,
+        bbox_epsg=None,
     ):
-        """ Create intermediate Geotiffs from a list of input RTCs
-
-        Parameters
-        ----------
-        input_list: list
-            The HDF5 file paths of input RTCs to be mosaicked.
-        scratch_dir: str
-            Directory which stores the temporary files
-        epsg_array: array of int
-            EPSG of each of the RTC input HDF5
-        data_path: dict
-            Nested dictionary containing input rtc with RTC image paths
-            key: input path, subkey: frequency group
-        layover_path: str
-            mask layer dataset path
-
-        Returns
-        -------
-        geogrid_in: DSWXGeogrid object
-            A dataclass object  representing the geographical grid
-            configuration for an RTC (Radar Terrain Correction) run.
-        output_gtiff_list: list
-            List of RTC Geotiffs derived from input RTC HDF5.
-        mask_gtiff_list: list
-            List of layoverShadow Mask Geotiffs derived from input RTC HDF5.
-        pol_gtiff_list: list
-            List of polarizations
         """
+        Create intermediate GeoTIFFs from input RTCs.
 
-        # Need to index data_path dict with both input rtc and freq_group
-        # Reproject geotiff
+        NEW: If bbox is provided, only reads/writes the intersection window for each RTC.
+            RTCs/datasets with no overlap are skipped.
+        """
+        # Majority EPSG for harmonization
         most_freq_epsg = majority_element(epsg_array)
         designated_value = np.float32(500)
 
@@ -304,44 +354,107 @@ class RTCReader(DataReader):
         mask_gtiff_list: list[str] = []
         pol_gtiff_list: dict[str, list[str]] = {}
 
+        # Small helper to compute crop window in source pixel coords
+        def bbox_to_window_for_ds(
+            bbox_in,
+            bbox_epsg_in: int,
+            ds_epsg_in: int,
+            transform_in: Affine,
+            width_in: int,
+            height_in: int,
+        ):
+            if bbox_in is None:
+                return (0, height_in, 0, width_in)
+
+            if bbox_epsg_in is None:
+                raise ValueError("bbox was provided but bbox_epsg is None")
+
+            # Reproject bbox to dataset EPSG if needed
+            if int(bbox_epsg_in) != int(ds_epsg_in):
+                bbox_ds = reproject_bbox(bbox_in, int(bbox_epsg_in), int(ds_epsg_in))
+            else:
+                bbox_ds = bbox_in
+
+            xmin, ymin, xmax, ymax = bbox_ds
+            xmin, xmax = (xmin, xmax) if xmin <= xmax else (xmax, xmin)
+            ymin, ymax = (ymin, ymax) if ymin <= ymax else (ymax, ymin)
+
+            # Dataset bounds in map coords
+            xs = [transform_in * (0, 0), transform_in * (width_in, 0),
+                transform_in * (0, height_in), transform_in * (width_in, height_in)]
+            xvals = [p[0] for p in xs]
+            yvals = [p[1] for p in xs]
+            ds_xmin, ds_xmax = min(xvals), max(xvals)
+            ds_ymin, ds_ymax = min(yvals), max(yvals)
+
+            # Intersection
+            ixmin = max(xmin, ds_xmin)
+            ixmax = min(xmax, ds_xmax)
+            iymin = max(ymin, ds_ymin)
+            iymax = min(ymax, ds_ymax)
+            if ixmin >= ixmax or iymin >= iymax:
+                return None
+
+            inv = ~transform_in
+            c0, r0 = inv * (ixmin, iymin)
+            c1, r1 = inv * (ixmax, iymax)
+
+            col_min = int(np.floor(min(c0, c1)))
+            col_max = int(np.ceil (max(c0, c1)))
+            row_min = int(np.floor(min(r0, r1)))
+            row_max = int(np.ceil (max(r0, r1)))
+
+            # Clamp
+            col_min = max(0, min(width_in,  col_min))
+            col_max = max(0, min(width_in,  col_max))
+            row_min = max(0, min(height_in, row_min))
+            row_max = max(0, min(height_in, row_max))
+
+            if col_min >= col_max or row_min >= row_max:
+                return None
+
+            return (row_min, row_max, col_min, col_max)
+
+        # ---- Write science layers (cropped if bbox provided) ----
         for input_idx, input_rtc in enumerate(input_list):
-            # Extract file names
             output_prefix = self.extract_file_name(input_rtc)
 
-            # Geo info + metadata (already use h5py under the hood)
+            # Geo info + metadata
             geotransform, crs = self.read_geodata_hdf5(input_rtc)
             dswx_metadata_dict = self.read_metadata_hdf5(input_rtc)
 
+            ds_epsg = int(epsg_array[input_idx])
+
             data_path_input = data_path[input_rtc]
-            freq = list(data_path_input.keys())
+            freq_groups = list(data_path_input.keys())
 
-            # Create intermediate GeoTIFFs for each dataset
-            for freq_group in freq:
-                dataset_path_list = data_path_input[freq_group]
-                for dataset_path in dataset_path_list:
+            for freq_group in freq_groups:
+                for dataset_path in data_path_input[freq_group]:
                     data_name = Path(dataset_path).name[:2]
-                    pol = dataset_path.split('/')[-1][:2]
+                    pol = dataset_path.split("/")[-1][:2]
 
-                    output_gtiff = f'{scratch_dir}/{output_prefix}_{data_name}_{freq_group}.tif'
-                    output_gtiff_list.append(output_gtiff)
+                    output_gtiff = f"{scratch_dir}/{output_prefix}_{data_name}_{freq_group}.tif"
 
-                    if pol not in pol_gtiff_list:
-                        pol_gtiff_list[pol] = []
-                    pol_gtiff_list[pol].append(output_gtiff)
-
-                    # --- h5py open and block read ---
                     with H5Reader(input_rtc) as f:
                         if dataset_path not in f:
                             raise RuntimeError(f"Dataset not found in HDF5: {dataset_path}")
-                        dset = f[dataset_path]               # h5py.Dataset
-                        print("shape:", dset.shape,
-                            "chunks:", dset.chunks,
-                            "compression:", dset.compression)
+                        dset = f[dataset_path]
                         if dset.ndim != 2:
                             raise RuntimeError(f"Expected 2D dataset, got shape {dset.shape} at {dataset_path}")
                         num_rows, num_cols = dset.shape
 
-                        # stream blocks → GeoTIFF
+                        win = bbox_to_window_for_ds(
+                            bbox, bbox_epsg, ds_epsg, geotransform, num_cols, num_rows
+                        )
+                        if win is None:
+                            logger.info(f"[BBox] skip {output_prefix} {data_name} {freq_group}: no overlap")
+                            continue
+
+                        r0, r1, c0, c1 = win
+                        out_rows = r1 - r0
+                        out_cols = c1 - c0
+
+                        # Write cropped GeoTIFF
                         self.read_write_rtc_h5py(
                             dset,
                             output_gtiff,
@@ -355,23 +468,38 @@ class RTCReader(DataReader):
                             crs,
                             dswx_metadata_dict,
                             is_mask=False,
-                            out_dtype='float32',
+                            out_dtype="float32",
+                            row0=r0,
+                            col0=c0,
+                            out_rows=out_rows,
+                            out_cols=out_cols,
+                            align_to_chunks=True,
+                            K_chunks=8,
                         )
 
-        # --- Harmonize EPSG / update geogrid as before ---
+                    output_gtiff_list.append(output_gtiff)
+                    pol_gtiff_list.setdefault(pol, []).append(output_gtiff)
+
+        # ---- EPSG harmonization + geogrid union ----
         geogrid_in = DSWXGeogrid()
+
+        # Harmonize EPSG if needed, update geogrid
         for input_idx, input_rtc in enumerate(input_list):
             input_prefix = self.extract_file_name(input_rtc)
+            ds_epsg = int(epsg_array[input_idx])
+
             data_path_input = data_path[input_rtc]
-            freq = list(data_path_input.keys())
+            freq_groups = list(data_path_input.keys())
 
-            if epsg_array[input_idx] != most_freq_epsg:
-                for freq_group in freq:
-                    for dataset_path in data_path_input[freq_group]:
-                        data_name = Path(dataset_path).name[:2]
-                        input_gtiff = f'{scratch_dir}/{input_prefix}_{data_name}_{freq_group}.tif'
-                        temp_gtiff = f'{scratch_dir}/{input_prefix}_temp_{data_name}_{freq_group}.tif'
+            for freq_group in freq_groups:
+                for dataset_path in data_path_input[freq_group]:
+                    data_name = Path(dataset_path).name[:2]
+                    input_gtiff = f"{scratch_dir}/{input_prefix}_{data_name}_{freq_group}.tif"
+                    if not os.path.exists(input_gtiff):
+                        continue  # could have been skipped due to bbox no-overlap
 
+                    if ds_epsg != most_freq_epsg:
+                        temp_gtiff = f"{scratch_dir}/{input_prefix}_temp_{data_name}_{freq_group}.tif"
                         change_epsg_tif(
                             input_tif=input_gtiff,
                             output_tif=temp_gtiff,
@@ -380,38 +508,43 @@ class RTCReader(DataReader):
                         )
                         geogrid_in.update_geogrid(temp_gtiff)
                         os.replace(temp_gtiff, input_gtiff)
-            else:
-                for freq_group in freq:
-                    for dataset_path in data_path_input[freq_group]:
-                        data_name = Path(dataset_path).name[:2]
-                        output_gtiff = f'{scratch_dir}/{input_prefix}_{data_name}_{freq_group}.tif'
-                        geogrid_in.update_geogrid(output_gtiff)
+                    else:
+                        geogrid_in.update_geogrid(input_gtiff)
 
-        # --- Layover/Shadow mask (read via h5py) ---
-        most_freq_epsg = majority_element(epsg_array)
-
+        # ---- Layover/Shadow mask (cropped if bbox provided) ----
         for input_idx, input_rtc in enumerate(input_list):
-            mask_ds_path = f'/{mask_path}' if not str(mask_path).startswith('/') else str(mask_path)
+            output_prefix = self.extract_file_name(input_rtc)
+            ds_epsg = int(epsg_array[input_idx])
+
+            mask_ds_path = f"/{mask_path}" if not str(mask_path).startswith("/") else str(mask_path)
+
+            # Open once to get shape and window
             with H5Reader(input_rtc) as f:
                 if mask_ds_path not in f:
-                    warnings.warn(f'\nDataset at {mask_ds_path} does not exist or cannot be opened.', RuntimeWarning)
+                    warnings.warn(f"\nDataset at {mask_ds_path} does not exist or cannot be opened.", RuntimeWarning)
                     continue
                 dset = f[mask_ds_path]
                 if dset.ndim != 2:
-                    warnings.warn(f'\nMask dataset not 2D: {mask_ds_path}', RuntimeWarning)
+                    warnings.warn(f"\nMask dataset not 2D: {mask_ds_path}", RuntimeWarning)
                     continue
                 num_rows, num_cols = dset.shape
 
-            geotransform, crs = self.read_geodata_hdf5(input_rtc)
-            dswx_metadata_dict = self.read_metadata_hdf5(input_rtc)
+                geotransform, crs = self.read_geodata_hdf5(input_rtc)
+                dswx_metadata_dict = self.read_metadata_hdf5(input_rtc)
 
-            output_prefix = self.extract_file_name(input_rtc)
-            output_mask_gtiff = f'{scratch_dir}/{output_prefix}_mask.tif'
-            mask_gtiff_list.append(output_mask_gtiff)
+                win = bbox_to_window_for_ds(
+                    bbox, bbox_epsg, ds_epsg, geotransform, num_cols, num_rows
+                )
+                if win is None:
+                    logger.info(f"[BBox] skip {output_prefix} mask: no overlap")
+                    continue
 
-            # stream mask blocks → GeoTIFF
-            with H5Reader(input_rtc) as f:
-                dset = f[mask_ds_path]
+                r0, r1, c0, c1 = win
+                out_rows = r1 - r0
+                out_cols = c1 - c0
+
+                output_mask_gtiff = f"{scratch_dir}/{output_prefix}_mask.tif"
+
                 self.read_write_rtc_h5py(
                     dset,
                     output_mask_gtiff,
@@ -425,12 +558,18 @@ class RTCReader(DataReader):
                     crs,
                     dswx_metadata_dict,
                     is_mask=True,
-                    out_dtype='uint8',
+                    out_dtype="uint8",
+                    row0=r0,
+                    col0=c0,
+                    out_rows=out_rows,
+                    out_cols=out_cols,
+                    align_to_chunks=True,
+                    K_chunks=8,
                 )
 
-            # EPSG harmonization
-            if epsg_array[input_idx] != most_freq_epsg:
-                tmp = f'{scratch_dir}/{output_prefix}_mask_tmp.tif'
+            # EPSG harmonization for mask
+            if ds_epsg != most_freq_epsg:
+                tmp = f"{scratch_dir}/{output_prefix}_mask_tmp.tif"
                 change_epsg_tif(
                     input_tif=output_mask_gtiff,
                     output_tif=tmp,
@@ -439,116 +578,157 @@ class RTCReader(DataReader):
                 )
                 os.replace(tmp, output_mask_gtiff)
 
+            mask_gtiff_list.append(output_mask_gtiff)
             geogrid_in.update_geogrid(output_mask_gtiff)
 
-        # --- Apply DB bbox constraint AFTER geogrid union is built ---
+        # ---- Optional: final clip of union geogrid to bbox (kept from your original) ----
         if bbox is not None:
-            # bbox is (xmin, ymin, xmax, ymax) in bbox_epsg
             if bbox_epsg is None:
                 raise ValueError("bbox was provided but bbox_epsg is None")
 
-            target_epsg = int(getattr(geogrid_in, "epsg", None))
-
-            # Reproject bbox to target_epsg if needed
+            target_epsg = int(getattr(geogrid_in, "epsg", most_freq_epsg))
             if int(bbox_epsg) != target_epsg:
                 bbox_use = reproject_bbox(bbox, int(bbox_epsg), target_epsg)
             else:
                 bbox_use = bbox
-            # Ensure geogrid EPSG matches target_epsg (after harmonization it should)
-            # If it doesn't, that's a bug earlier — but we can force it here safely.
+
             ge_epsg = getattr(geogrid_in, "epsg", None)
             if ge_epsg is None or int(ge_epsg) != target_epsg:
                 geogrid_in.epsg = target_epsg
 
-            # Now bbox_use is in target_epsg, so pass bbox_epsg=target_epsg
             geogrid_in.clip_to_bbox(bbox_use, bbox_epsg=target_epsg, snap=True)
+            logger.info(f"[BBox clip] final geogrid bounds: {geogrid_in.bounds()}, epsg={geogrid_in.epsg}")
 
-            bx = geogrid_in.bounds()
-            logger.info(f"[BBox clip] final geogrid bounds: {bx}, epsg={geogrid_in.epsg}")
         return geogrid_in, output_gtiff_list, mask_gtiff_list, pol_gtiff_list
 
+
     def read_write_rtc_h5py(
-        self,
-        h5_dset: h5py.Dataset,
-        output_gtiff: str,
-        num_rows: int,
-        num_cols: int,
-        row_blk_size: int,
-        col_blk_size: int,
-        gdal_cache_max_mb,
-        designated_value: np.float32,
-        geotransform: Affine,
-        crs: str,
-        dswx_metadata_dict: dict,
-        *,
-        is_mask: bool = False,
-        out_dtype: str | None = None):
-        """
-        Stream a 2D h5py dataset in blocks and write GeoTIFF via rasterio.
+            self,
+            h5_dset: h5py.Dataset,
+            output_gtiff: str,
+            num_rows: int,
+            num_cols: int,
+            row_blk_size: int,
+            col_blk_size: int,
+            gdal_cache_max_mb,
+            designated_value: np.float32,
+            geotransform: Affine,
+            crs: str,
+            dswx_metadata_dict: dict,
+            *,
+            is_mask: bool = False,
+            out_dtype: str | None = None,
+            # NEW: crop window in source pixel coordinates
+            row0: int = 0,
+            col0: int = 0,
+            out_rows: int | None = None,
+            out_cols: int | None = None,
+            # NEW: optionally align row reads to HDF5 chunk rows for speed
+            align_to_chunks: bool = True,
+            K_chunks: int = 8,
+        ):
+            """
+            Stream a 2D h5py dataset in blocks and write GeoTIFF via rasterio.
 
-        h5_dset: h5py.Dataset with shape (rows, cols)
-        """
-        if out_dtype is None:
-            out_dtype = 'uint8' if is_mask else 'float32'
-        dst_dtype = np.uint8 if out_dtype == 'uint8' else np.float32
+            Supports optional cropping: reads source window [row0:row0+out_rows, col0:col0+out_cols]
+            and writes to an output GeoTIFF whose transform is shifted accordingly.
 
-        profile = {
-            'driver': 'GTiff',
-            'height': num_rows,
-            'width': num_cols,
-            'count': 1,
-            'tiled': True,
-            'blockxsize': 512,
-            'blockysize': 512,
-            'dtype': out_dtype,
-            'crs': crs,
-            'transform': geotransform,
-            'compress': 'DEFLATE',
-            'interleave': 'band',
-        }
-        if is_mask:
-            profile['nodata'] = 255
+            h5_dset: h5py.Dataset with shape (rows, cols)
+            """
+            if out_dtype is None:
+                out_dtype = "uint8" if is_mask else "float32"
+            dst_dtype = np.uint8 if out_dtype == "uint8" else np.float32
 
-        def aligned_ranges(n_rows, blk, align):
-            r = 0
-            # align the first read
-            if r % align != 0:
-                a = r + (align - (r % align))
-                yield slice(r, min(a, n_rows))
-                r = a
-            while r < n_rows:
-                yield slice(r, min(r + blk, n_rows))
-                r += blk
+            # Output shape defaults to full raster
+            if out_rows is None:
+                out_rows = num_rows - row0
+            if out_cols is None:
+                out_cols = num_cols - col0
 
-        chunk = h5_dset.chunks or (512, 512)  # fallback if unchunked
-        chunk_rows = chunk[0]
+            # Sanity + clamp
+            if row0 < 0 or col0 < 0:
+                raise ValueError(f"row0/col0 must be >=0, got row0={row0}, col0={col0}")
+            if row0 + out_rows > num_rows or col0 + out_cols > num_cols:
+                raise ValueError(
+                    f"Crop window out of bounds: "
+                    f"src ({num_rows},{num_cols}), "
+                    f"window row[{row0}:{row0+out_rows}] col[{col0}:{col0+out_cols}]"
+                )
+            if out_rows <= 0 or out_cols <= 0:
+                raise ValueError(f"Invalid output size out_rows={out_rows}, out_cols={out_cols}")
 
-        # Read K chunk-rows at a time (tune K by RAM; 4–16 is a good start)
-        K = 8
-        row_blk_size = K * chunk_rows
-        col_blk_size = num_cols  # full width stripes
-    
-        with rasterio.Env(GDAL_CACHEMAX=gdal_cache_max_mb):
-            with rasterio.open(output_gtiff, 'w', **profile) as dst:
-                for s in aligned_ranges(num_rows, row_blk_size, chunk_rows):
+            # Shift transform so pixel (0,0) corresponds to original (col0,row0)
+            out_transform = geotransform * Affine.translation(col0, row0)
 
-                    rs, re = s.start, s.stop
+            profile = {
+                "driver": "GTiff",
+                "height": out_rows,
+                "width": out_cols,
+                "count": 1,
+                "dtype": out_dtype,
+                "crs": crs,
+                "transform": out_transform,
+                "compress": "DEFLATE",
+                "tiled": True,
+                "blockxsize": 512,
+                "blockysize": 512,
+                'interleave': 'band',
+            }
+            if is_mask:
+                profile["nodata"] = 255
 
-                    ds_blk = h5_dset[rs:re, 0:num_cols]
+            # Helpers for aligned row reading
+            def aligned_ranges(start_row: int, stop_row: int, blk: int, align: int):
+                r = start_row
+                # align the first read to chunk boundary if requested
+                if align > 1 and (r % align) != 0:
+                    a = r + (align - (r % align))
+                    yield slice(r, min(a, stop_row))
+                    r = a
+                while r < stop_row:
+                    yield slice(r, min(r + blk, stop_row))
+                    r += blk
 
-                    if is_mask:
-                        blk = ds_blk.astype(np.int32, copy=False)
-                        # Replace non-finite with nodata=255
-                        blk = np.where(np.isfinite(blk), blk, 255).astype(dst_dtype, copy=False)
-                    else:
-                        blk = ds_blk.astype(np.float32, copy=False)
-                        blk[np.isinf(blk)] = designated_value
-                        blk[blk > designated_value] = designated_value
-                        blk[blk == 0] = np.nan
+            # Decide row stripe height
+            chunk = h5_dset.chunks or (512, 512)
+            chunk_rows = int(chunk[0]) if chunk and len(chunk) >= 2 else 512
 
-                    dst.write(blk, 1, window=Window(0, rs, num_cols, re - rs))
+            if align_to_chunks and chunk_rows > 0:
+                row_blk_size_eff = int(K_chunks) * chunk_rows
+                align = chunk_rows
+            else:
+                row_blk_size_eff = int(row_blk_size)
+                align = 1
 
-                dst.update_tags(**dswx_metadata_dict)
+            # We write full-width stripes of the cropped window
+            col_blk_size_eff = out_cols
+
+            src_r0 = row0
+            src_r1 = row0 + out_rows
+            with rasterio.Env(GDAL_CACHEMAX=gdal_cache_max_mb):
+
+                with rasterio.open(output_gtiff, "w", **profile) as dst:
+                    for s in aligned_ranges(src_r0, src_r1, row_blk_size_eff, align):
+                        rs, re = int(s.start), int(s.stop)
+
+                        # Read from HDF5 window (source coords)
+                        ds_blk = h5_dset[rs:re, col0 : col0 + out_cols]
+
+                        # Convert / clean
+                        if is_mask:
+                            blk = ds_blk.astype(np.int32, copy=False)
+                            blk = np.where(np.isfinite(blk), blk, 255).astype(dst_dtype, copy=False)
+                        else:
+                            blk = ds_blk.astype(np.float32, copy=False)
+                            blk[np.isinf(blk)] = designated_value
+                            blk[blk > designated_value] = designated_value
+                            blk[blk == 0] = np.nan
+
+                        # Write into output at row offset (destination coords start at 0)
+                        dst_rs = rs - src_r0
+                        dst.write(blk, 1, window=Window(0, dst_rs, out_cols, re - rs))
+
+                    dst.update_tags(**dswx_metadata_dict)
 
 
     def mosaic_rtc_geotiff(
@@ -787,7 +967,7 @@ class RTCReader(DataReader):
             # Directly average 10m resolution input to 30m resolution output
             ds_array = ds_input.GetRasterBand(1).ReadAsArray()
 
-            multi_look_output = _aggregate_10m_to_30m_conv(
+            multi_look_output = _aggregate_10m_to_30m_fast(
                 ds_array,
                 downsamp_ratio,
                 normalized_flag,

--- a/src/dswx_sar/defaults/algorithm_parameter_s1.yaml
+++ b/src/dswx_sar/defaults/algorithm_parameter_s1.yaml
@@ -43,6 +43,8 @@ runconfig:
             #   - average : overlapped areas are averaged.
             #   - first : choose one burst without average.
             mosaic_mode: 'first'
+            read_row_blk_size: 2048
+            read_col_blk_size: 2048
 
         # Flag to turn on/off the filtering for RTC image.
         # The enhanced Lee filter is available.

--- a/src/dswx_sar/schemas/algorithm_parameter_s1.yaml
+++ b/src/dswx_sar/schemas/algorithm_parameter_s1.yaml
@@ -37,6 +37,8 @@ runconfig:
             mosaic_prefix: str(required=False)
             mosaic_cog_enable: bool(required=False)
             mosaic_mode: str(required=False)
+            read_row_blk_size: int(min=1, required=False)
+            read_col_blk_size: int(min=1, required=False)
         # Flag to turn on/off the filtering for RTC image.
         # The enhanced Lee filter is available.
         filter:


### PR DESCRIPTION
This PR fixes the offset issue. 

- mosaic image shows the offset when comparing result with the image before mosaic
- 0.5 offset, which was hardcorded causes the problem. 
- Also, when applying the gdalwarp, we added option ` targetAlignedPixels=True`

Additionally, this PR reads only subset of GCOV, which fall in `geogrid_in` when converting HDF5 to Geotiff format. 
This reduces the processing time and memory usage. 