### PR TITLE
Fixed configuration item misplaced and corrected non-integer bbox coo…

### DIFF
--- a/src/dswx_sar/common/_masking_with_ancillary.py
+++ b/src/dswx_sar/common/_masking_with_ancillary.py
@@ -2341,12 +2341,12 @@ def hand_filter_along_boundary_componentwise(
             continue
 
         # bbox + buffer
-        x0 = max(0, x - buffer_pixels)
-        y0 = max(0, y - buffer_pixels)
-        x1 = min(xsize, x + w + buffer_pixels)
-        y1 = min(ysize, y + h + buffer_pixels)
-        win_w = x1 - x0
-        win_h = y1 - y0
+        x0 = int(max(0, x - buffer_pixels))
+        y0 = int(max(0, y - buffer_pixels))
+        x1 = int(min(xsize, x + w + buffer_pixels))
+        y1 = int(min(ysize, y + h + buffer_pixels))
+        win_w = int(x1 - x0)
+        win_h = int(y1 - y0)
 
         # Component mask in window
         sub_label = labels[y0:y1, x0:x1]

--- a/src/dswx_sar/defaults/algorithm_parameter_ni.yaml
+++ b/src/dswx_sar/defaults/algorithm_parameter_ni.yaml
@@ -138,6 +138,7 @@ runconfig:
             number_cpu: -1
             tile_average: True
             line_per_block: 300
+            threshold_scale: 'linear'
 
         fuzzy_value:
             line_per_block: 200
@@ -216,7 +217,6 @@ runconfig:
             hand_variation_threshold: 2.5
             line_per_block: 400
             number_cpu: 1
-            threshold_scale: 'linear'
 
         refine_with_bimodality:
             minimum_pixel: 4


### PR DESCRIPTION
algorithm_parameter_ni.yaml: threshold_scale: 'linear' should be under 'initial_threshold'
./common/_masking_with_ancillary.py:  The bbox coordinates should be integer.

# bbox + buffer
2345         x0 = int(max(0, x - buffer_pixels))
2346         y0 = int(max(0, y - buffer_pixels))
2347         x1 = int(min(xsize, x + w + buffer_pixels))
2348         y1 = int(min(ysize, y + h + buffer_pixels))
2349         win_w = int(x1 - x0)
2350         win_h = int(y1 - y0)

