### PR TITLE
fix a bug in reading data in s3

### DIFF
--- a/src/dswx_sar/nisar/dswx_ni_runconfig.py
+++ b/src/dswx_sar/nisar/dswx_ni_runconfig.py
@@ -197,12 +197,12 @@ def check_file_path(file_path: str) -> None:
     if file_path.startswith('/vsis3/'):
         check_gdal_raster_s3(file_path, raise_error=True)
 
-    if file_path.startswith('s3://'):
+    elif file_path.startswith('s3://'):
         if not file_exists(file_path, profile="saml-pub"):
             raise FileNotFoundError(f"{file_path} not found (S3 head_object failed)")
         return
 
-    if not os.path.exists(file_path):
+    elif not os.path.exists(file_path):
         raise FileNotFoundError(f"{file_path} not found")
 
 


### PR DESCRIPTION
This PR fixes a bug in reading data from an S3 bucket.

In dswx_ni_runconfig.py, the code checks whether input files are stored locally or in an S3 bucket. However, the if statement was incorrect and raised an error when the data was stored in S3.