### PR TITLE
Improve initial-threshold stability and cross-platform reproducibility

### DIFF
--- a/src/dswx_sar/common/_dswx_sar_util.py
+++ b/src/dswx_sar/common/_dswx_sar_util.py
@@ -530,7 +530,7 @@ def _save_as_cog(filename,
                  flag_compress=True,
                  ovr_resamp_algorithm=None,
                  compression='DEFLATE',
-                 nbits=16):
+                 nbits=None):
     """Save (overwrite) a GeoTIFF file as a cloud-optimized GeoTIFF.
 
     Parameters
@@ -607,24 +607,41 @@ def _save_as_cog(filename,
     else:
         gdal_translate_options.append('PREDICTOR=3')
 
-    effective_nbits = _sanitize_nbits_for_dtype(gdal_dtype, nbits)
+    # Do not apply NBITS to floating-point rasters.
+    # NBITS=16 on Float32 can produce half-precision-like storage,
+    # which causes platform-dependent float16/float32 read behavior.
+    if is_integer:
+        effective_nbits = _sanitize_nbits_for_dtype(gdal_dtype, nbits)
 
-    if effective_nbits is not None:
-        gdal_translate_options.append(f'NBITS={effective_nbits}')
+        if effective_nbits is not None:
+            gdal_translate_options.append(f'NBITS={effective_nbits}')
 
-        if logger is not None and effective_nbits != nbits:
+            if logger is not None and effective_nbits != nbits:
+                logger.info(
+                    f'        Adjusted NBITS from {nbits} to {effective_nbits} '
+                    f'for dtype {gdal.GetDataTypeName(gdal_dtype)}'
+                )
+    else:
+        effective_nbits = None
+        if nbits is not None and logger is not None:
             logger.info(
-                f'        Adjusted NBITS from {nbits} to {effective_nbits} '
-                f'for dtype {gdal.GetDataTypeName(gdal_dtype)}'
+                f'        Ignoring NBITS={nbits} for floating-point dtype '
+                f'{gdal.GetDataTypeName(gdal_dtype)}'
             )
 
     try:
+        translate_kwargs = {
+            "creationOptions": gdal_translate_options,
+        }
+
+        if not is_integer:
+            translate_kwargs["outputType"] = gdal.GDT_Float32
+
         out_ds = gdal.Translate(
             temp_file,
             filename,
-            creationOptions=gdal_translate_options
+            **translate_kwargs
         )
-
         if out_ds is None:
             raise RuntimeError(f'gdal.Translate failed for {filename}')
 
@@ -1786,9 +1803,12 @@ def write_raster_block(out_raster, data,
 
     # Write COG is cog_flag is True and last block.
     if (block_param.write_start_line + block_param.block_length ==
-       block_param.data_length) and cog_flag:
-        _save_as_cog(out_raster, scratch_dir)
+    block_param.data_length) and cog_flag:
 
+        if datatype in ['float32', 'float64', 'float']:
+            _save_as_cog(out_raster, scratch_dir, nbits=None)
+        else:
+            _save_as_cog(out_raster, scratch_dir)
 
 def block_param_generator(lines_per_block, data_shape, pad_shape):
     ''' Generator for block specific parameter class.

--- a/src/dswx_sar/common/_fuzzy_value_computation.py
+++ b/src/dswx_sar/common/_fuzzy_value_computation.py
@@ -31,13 +31,25 @@ def compute_slope_dem(dem):
     sl : numpy.ndarray
         slope angle raster
     '''
-    sobelx = cv2.Sobel(dem, cv2.CV_64F, 1, 0, ksize=SOBEL_KERNEL_SIZE)  # x
-    sobely = cv2.Sobel(dem, cv2.CV_64F, 0, 1, ksize=SOBEL_KERNEL_SIZE)  # y
 
-    # Compute slope
-    slope_angle = np.arctan(np.sqrt(
-        (sobelx / SOBEL_KERNEL_SIZE / PIXEL_RESOLUTION_X) ** 2 +
-        (sobely / SOBEL_KERNEL_SIZE / PIXEL_RESOLUTION_Y) ** 2)) * RAD_TO_DEG
+    dem = np.asarray(dem, dtype=np.float64)
+
+    valid = np.isfinite(dem)
+    dem_filled = np.where(valid, dem, np.nanmedian(dem))
+
+    dz_dy, dz_dx = np.gradient(
+        dem_filled,
+        PIXEL_RESOLUTION_Y,
+        PIXEL_RESOLUTION_X,
+    )
+
+    slope_angle = np.degrees(
+        np.arctan(
+            np.sqrt(dz_dx**2 + dz_dy**2)
+        )
+    )
+
+    slope_angle[~valid] = np.nan
 
     return slope_angle
 

--- a/src/dswx_sar/common/_initial_threshold.py
+++ b/src/dswx_sar/common/_initial_threshold.py
@@ -20,6 +20,67 @@ from dswx_sar.common import (_region_growing)
 logger = logging.getLogger('dswx_sar')
 
 
+import json
+from pathlib import Path
+import numpy as np
+
+
+
+def _debug_safe_float(x):
+    try:
+        x = float(x)
+        if np.isfinite(x):
+            return x
+        return None
+    except Exception:
+        return None
+
+
+def _debug_array_summary(a):
+    a = np.asarray(a)
+    finite = np.isfinite(a)
+
+    out = {
+        "shape": list(a.shape),
+        "size": int(a.size),
+        "n_finite": int(finite.sum()),
+        "n_nan": int(np.isnan(a).sum()) if np.issubdtype(a.dtype, np.number) else None,
+        "n_inf": int(np.isinf(a).sum()) if np.issubdtype(a.dtype, np.number) else None,
+    }
+
+    if finite.any():
+        af = a[finite].astype(np.float64)
+        out.update({
+            "min": _debug_safe_float(np.min(af)),
+            "max": _debug_safe_float(np.max(af)),
+            "mean": _debug_safe_float(np.mean(af)),
+            "std": _debug_safe_float(np.std(af)),
+            "median": _debug_safe_float(np.median(af)),
+        })
+    else:
+        out.update({
+            "min": None,
+            "max": None,
+            "mean": None,
+            "std": None,
+            "median": None,
+        })
+
+    return out
+
+
+def _write_tile_metric_record(out_dir, record):
+    if out_dir is None:
+        return
+
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    path = out_dir / "tile_metric_manifest.jsonl"
+    with open(path, "a") as f:
+        f.write(json.dumps(record, sort_keys=True) + "\n")
+
+
 def convert_pow2db(intensity):
     """Convert power to decibels
 
@@ -42,7 +103,9 @@ class TileSelection:
         self.wbd_max_value = ref_water_max
         self.threshold_twele = [0.09, 0.8, 0.97]
         self.threshold_bimodality = 0.7
-
+        self.debug_tile_metric = False
+        self.debug_metric_dir = None
+        self.debug_context = {}
     def rescale_value(self,
                       raster,
                       min_value,
@@ -73,7 +136,8 @@ class TileSelection:
                                threshold=0.7,
                                min_intensity_histogram=-30,
                                max_intensity_histogram=5,
-                               numstep=100):
+                               numstep=100,
+                           return_metric=False):
         ''' Select tiles with bimodal distribution
 
         Parameters
@@ -141,7 +205,18 @@ class TileSelection:
         max_sigma = np.nanmax(sigma)
         select_flag = max_sigma > threshold
 
-        return max_sigma, sigma, select_flag
+        if not return_metric:
+            return max_sigma, sigma, select_flag
+
+        metric = {
+            "bimodality_max_sigma": _debug_safe_float(max_sigma),
+            "bimodality_threshold": _debug_safe_float(threshold),
+            "bimodality_select_flag": bool(select_flag),
+            "intensity_db": _debug_array_summary(intensity_db),
+            "sigma": _debug_array_summary(sigma),
+        }
+
+        return max_sigma, sigma, select_flag, metric
 
     def select_tile_twele(self,
                           intensity_gray,
@@ -195,7 +270,8 @@ class TileSelection:
         return select_flag, cvx, rx
 
     def select_tile_chini(self,
-                          intensity):
+                          intensity, return_metric=False
+                          ):
         """Select tiles based on Chini's method
         Chini, M., Hostache, R., Giustarini, L., & Matgen, P. (2017).
         A hierarchical split-based approach for parametric thresholding
@@ -214,12 +290,151 @@ class TileSelection:
             Returns True if the tile's intensity distribution is bimodal,
             and False otherwise.
         """
-        metric_obj = _refine_with_bimodality.BimodalityMetrics(
-                    intensity)
+        metric_obj = _refine_with_bimodality.BimodalityMetrics(intensity)
         select_flag = metric_obj.compute_metric()
 
-        return select_flag
+        if not return_metric:
+            return select_flag
 
+        metric = {
+            "chini_select_flag": bool(select_flag),
+            "chini_enough_number": bool(getattr(metric_obj, "enough_number", False)),
+            "chini_optimization": bool(getattr(metric_obj, "optimization", False)),
+            "threshold_global_otsu": _debug_safe_float(
+                getattr(metric_obj, "threshold_global_otsu", np.nan)
+            ),
+        }
+
+        try:
+            ashman, bhc, surface_ratio, bm_coeff, bc_coeff = metric_obj.get_metric()
+
+            thresholds = [1.5, 0.97, 0.1, 0.7]
+
+            ashman_bool = ashman > thresholds[0]
+            bm_coeff_bool = bm_coeff > thresholds[3]
+            surface_ratio_bool = surface_ratio > thresholds[2]
+            bc_coeff_bool = bc_coeff > 5 / 9
+
+            bimodal_metrics = (
+                int(ashman_bool) +
+                int(bm_coeff_bool) +
+                int(bc_coeff_bool)
+            )
+            first_mode = getattr(metric_obj, "first_mode", None)
+            second_mode = getattr(metric_obj, "second_mode", None)
+            params = getattr(metric_obj, "params", None)
+
+            chini_fit_invalid = False
+
+            if first_mode is None or second_mode is None or params is None:
+                chini_fit_invalid = True
+            else:
+                first_mode_arr = np.asarray(first_mode, dtype=np.float64).ravel()
+                second_mode_arr = np.asarray(second_mode, dtype=np.float64).ravel()
+                params_arr = np.asarray(params, dtype=np.float64).ravel()
+
+                if first_mode_arr.size < 3 or second_mode_arr.size < 3:
+                    chini_fit_invalid = True
+                else:
+                    m1, s1, a1 = first_mode_arr[:3]
+                    m2, s2, a2 = second_mode_arr[:3]
+
+                    tile_db = convert_pow2db(intensity)
+                    tile_db = tile_db[np.isfinite(tile_db)]
+
+                    if tile_db.size > 0:
+                        tile_min = float(np.nanmin(tile_db))
+                        tile_max = float(np.nanmax(tile_db))
+                    else:
+                        tile_min = None
+                        tile_max = None
+
+                    mean_sep = abs(m2 - m1)
+
+                    chini_fit_invalid = (
+                        (not np.all(np.isfinite(params_arr))) or
+                        (not np.all(np.isfinite(first_mode_arr))) or
+                        (not np.all(np.isfinite(second_mode_arr))) or
+                        (s1 < 0.05) or
+                        (s2 < 0.05) or
+                        (s1 > 3.0) or
+                        (s2 > 3.0) or
+                        (a1 >= 0.98) or
+                        (a2 >= 0.98) or
+                        (mean_sep < 0.5) or
+                        (mean_sep > 8.0)
+                    )
+
+                    if tile_min is not None and tile_max is not None:
+                        pad = 1.0
+                        if not (tile_min - pad <= m1 <= tile_max + pad):
+                            chini_fit_invalid = True
+                        if not (tile_min - pad <= m2 <= tile_max + pad):
+                            chini_fit_invalid = True
+
+            if chini_fit_invalid:
+                select_flag = False
+                ashman_bool = False
+                bm_coeff_bool = False
+                surface_ratio_bool = False
+                bc_coeff_bool = False
+                bimodal_metrics = 0
+
+            metric.update({
+                "chini_ashman": _debug_safe_float(ashman),
+                "chini_bhc": _debug_safe_float(bhc),
+                "chini_surface_ratio": _debug_safe_float(surface_ratio),
+                "chini_bm_coeff": _debug_safe_float(bm_coeff),
+                "chini_bc_coeff": _debug_safe_float(bc_coeff),
+
+                "chini_ashman_bool": bool(ashman_bool),
+                "chini_bm_coeff_bool": bool(bm_coeff_bool),
+                "chini_surface_ratio_bool": bool(surface_ratio_bool),
+                "chini_bc_coeff_bool": bool(bc_coeff_bool),
+                "chini_bimodal_metrics": int(bimodal_metrics),
+
+                "chini_condition_1": bool((bimodal_metrics >= 2) or (ashman > 3)),
+                "chini_condition_2": bool(surface_ratio_bool),
+            })
+            metric.update({
+
+                "chini_first_mode": [
+                    _debug_safe_float(x) for x in np.asarray(
+                        getattr(metric_obj, "first_mode", [])
+                    ).ravel()
+                ] if hasattr(metric_obj, "first_mode") else None,
+
+                "chini_second_mode": [
+                    _debug_safe_float(x) for x in np.asarray(
+                        getattr(metric_obj, "second_mode", [])
+                    ).ravel()
+                ] if hasattr(metric_obj, "second_mode") else None,
+                "chini_params": [
+                    _debug_safe_float(x) for x in np.asarray(
+                        getattr(metric_obj, "params", [])
+                    ).ravel()
+                ],
+                "chini_expected": [
+                    _debug_safe_float(x) for x in np.asarray(
+                        getattr(metric_obj, "expected", [])
+                    ).ravel()
+                ],
+            })
+        except Exception as e:
+            metric["chini_metric_error"] = str(e)
+
+        # Also save fitted modes if available.
+        for attr in ["first_mode", "second_mode"]:
+            if hasattr(metric_obj, attr):
+                val = getattr(metric_obj, attr)
+                try:
+                    metric[f"chini_{attr}"] = [
+                        _debug_safe_float(x) for x in np.asarray(val).ravel()
+                    ]
+                except Exception:
+                    pass
+
+        return select_flag, metric
     def get_water_portion_mask(self, water_mask):
         """
         Check if a water mask image contains both water and non-water areas.
@@ -415,13 +630,54 @@ class TileSelection:
 
                                 # Initially set flag as True
                                 tile_selected_flag = True
-
+                                tile_metric_record = {
+                                    **(getattr(self, "debug_context", {}) or {}),
+                                    "tile_id": int(ind_subtile),
+                                    "subrun": int(subrun),
+                                    "win_size": int(win_size),
+                                    "coord_local": [
+                                        int(x_start), int(x_end),
+                                        int(y_start), int(y_end)
+                                    ],
+                                    "validnum": int(validnum),
+                                    "water_number_sample_sub": int(water_number_sample_sub),
+                                    "water_area_sublock_flag": bool(water_area_sublock_flag),
+                                    "num_pixel_max": _debug_safe_float(num_pixel_max),
+                                    "intensity_sub": _debug_array_summary(intensity_sub),
+                                    "water_mask_sublock": _debug_array_summary(water_mask_sublock),
+                                    "checked": True,
+                                    "pass_twele": None,
+                                    "pass_chini": None,
+                                    "pass_bimodality": None,
+                                }
+                                ctx = getattr(self, "debug_context", {}) or {}
+                                if ctx.get("block_origin") is not None:
+                                    row0, col0 = ctx["block_origin"]
+                                    tile_metric_record["coord_absolute"] = [
+                                        int(row0 + x_start), int(row0 + x_end),
+                                        int(col0 + y_start), int(col0 + y_end),
+                                    ]
                                 if {'twele', 'combined'}.intersection(
                                         set(selection_methods)):
-                                    tile_selected_flag, _, _ = \
-                                        self.select_tile_twele(
-                                            intensity_sub_gray,
-                                            mean_intensity_global)
+                                    # tile_selected_flag, _, _ = \
+                                    #     self.select_tile_twele(
+                                    #         intensity_sub_gray,
+                                    #         mean_intensity_global)
+                                    # if tile_selected_flag:
+                                    #     selected_tile_twele.append(True)
+                                    # else:
+                                    #     selected_tile_twele.append(False)
+
+
+
+                                    tile_selected_flag, cvx, rx = self.select_tile_twele(
+                                        intensity_sub_gray,
+                                        mean_intensity_global)
+
+                                    tile_metric_record["pass_twele"] = bool(tile_selected_flag)
+                                    tile_metric_record["twele_cvx"] = _debug_safe_float(cvx)
+                                    tile_metric_record["twele_rx"] = _debug_safe_float(rx)
+
                                     if tile_selected_flag:
                                         selected_tile_twele.append(True)
                                     else:
@@ -440,16 +696,27 @@ class TileSelection:
                                         selected_tile_chini.append(False)
 
                                     else:
-                                        tile_selected_flag = \
-                                            self.select_tile_chini(
-                                                intensity_sub
-                                                )
+                                        # tile_selected_flag = \
+                                        #     self.select_tile_chini(
+                                        #         intensity_sub
+                                        #         )
+
+                                        # if tile_selected_flag:
+                                        #     selected_tile_chini.append(True)
+                                        # else:
+                                        #     selected_tile_chini.append(False)
+                                        tile_selected_flag, chini_metric = self.select_tile_chini(
+                                            intensity_sub,
+                                            return_metric=True
+                                        )
+
+                                        tile_metric_record["pass_chini"] = bool(tile_selected_flag)
+                                        tile_metric_record.update(chini_metric)
 
                                         if tile_selected_flag:
                                             selected_tile_chini.append(True)
                                         else:
                                             selected_tile_chini.append(False)
-
                                 else:
                                     selected_tile_chini.append(False)
 
@@ -461,11 +728,14 @@ class TileSelection:
 
                                         selected_tile_bimodality.append(False)
                                     else:
-                                        _, _, tile_bimode_flag = \
-                                            self.select_tile_bimodality(
-                                                intensity_sub,
-                                                threshold=self.threshold_bimodality
-                                                )
+                                        _, _, tile_bimode_flag, bimodality_metric = self.select_tile_bimodality(
+                                            intensity_sub,
+                                            threshold=self.threshold_bimodality,
+                                            return_metric=True
+                                        )
+
+                                        tile_metric_record["pass_bimodality"] = bool(tile_bimode_flag)
+                                        tile_metric_record.update(bimodality_metric)
 
                                         if tile_bimode_flag:
                                             selected_tile_bimodality.append(
@@ -478,12 +748,62 @@ class TileSelection:
                                 else:
                                     selected_tile_bimodality.append(False)
 
+                                if getattr(self, "debug_tile_metric", False):
+                                    if "combined" in selection_methods:
+                                        final_pass = (
+                                            bool(tile_metric_record.get("pass_twele")) and
+                                            bool(tile_metric_record.get("pass_chini")) and
+                                            bool(tile_metric_record.get("pass_bimodality"))
+                                        )
+                                    else:
+                                        final_pass = True
+                                        if "twele" in selection_methods:
+                                            final_pass = final_pass and bool(tile_metric_record.get("pass_twele"))
+                                        if "chini" in selection_methods:
+                                            final_pass = final_pass and bool(tile_metric_record.get("pass_chini"))
+                                        if "bimodality" in selection_methods:
+                                            final_pass = final_pass and bool(tile_metric_record.get("pass_bimodality"))
+
+                                    tile_metric_record["passed_final_estimate"] = bool(final_pass)
+
+                                    _write_tile_metric_record(
+                                        getattr(self, "debug_metric_dir", None),
+                                        tile_metric_record
+                                    )
+
+
                             else:
                                 bimodality_max_set.append(np.nan)
                                 selected_tile_twele.append(False)
                                 selected_tile_chini.append(False)
                                 selected_tile_bimodality.append(False)
+                                if getattr(self, "debug_tile_metric", False):
+                                    ctx = getattr(self, "debug_context", {}) or {}
+                                    record = {
+                                        **ctx,
+                                        "tile_id": int(ind_subtile),
+                                        "subrun": int(subrun),
+                                        "win_size": int(win_size),
+                                        "coord_local": [
+                                            int(x_start), int(x_end),
+                                            int(y_start), int(y_end)
+                                        ],
+                                        "validnum": int(validnum),
+                                        "water_number_sample_sub": int(water_number_sample_sub),
+                                        "water_area_sublock_flag": bool(water_area_sublock_flag),
+                                        "num_pixel_max": _debug_safe_float(num_pixel_max),
+                                        "checked": False,
+                                        "skip_reason": "not_enough_valid_or_no_water_land_boundary",
+                                        "pass_twele": False,
+                                        "pass_chini": False,
+                                        "pass_bimodality": False,
+                                        "passed_final_estimate": False,
+                                    }
 
+                                    _write_tile_metric_record(
+                                        getattr(self, "debug_metric_dir", None),
+                                        record
+                                    )
                             # keep coordinates for the searching window.
                             coordinate.append(
                                 [ind_subtile,
@@ -758,6 +1078,78 @@ def compute_ki_threshold(
     threshold = intensity_bins[index_ki_threshold]
 
     return threshold, index_ki_threshold
+
+
+def compute_ki_threshold_from_hist(intensity_bins, intensity_counts):
+    """
+    Compute KI threshold from a precomputed canonical histogram.
+
+    This avoids recomputing np.histogram inside _initial_threshold.compute_ki_threshold,
+    which can reintroduce Intel/Mac differences.
+    """
+    intensity_bins = np.asarray(intensity_bins, dtype=np.float64)
+    intensity_counts = np.asarray(intensity_counts, dtype=np.float64)
+    intensity_counts = np.nan_to_num(
+        intensity_counts,
+        nan=0.0,
+        posinf=0.0,
+        neginf=0.0
+    )
+
+    negligible_value = _dswx_sar_util.Constants.negligible_value
+
+    intensity_cumsum = np.cumsum(intensity_counts)
+    intensity_cumsum = np.where(
+        intensity_cumsum <= 0,
+        negligible_value,
+        intensity_cumsum
+    )
+
+    intensity_area = np.cumsum(intensity_counts * intensity_bins)
+    intensity_s = np.cumsum(intensity_counts * intensity_bins ** 2)
+
+    var_f = intensity_s / intensity_cumsum - (
+        intensity_area / intensity_cumsum
+    ) ** 2
+    var_f = np.where(var_f <= 0, negligible_value, var_f)
+    sigma_f = np.sqrt(var_f)
+
+    cb = intensity_cumsum[-1] - intensity_cumsum
+    cb = np.where(cb <= 0, negligible_value, cb)
+
+    mb = intensity_area[-1] - intensity_area
+    sb = intensity_s[-1] - intensity_s
+
+    var_b = sb / cb - (mb / cb) ** 2
+    var_b = np.where(var_b <= 0, negligible_value, var_b)
+    sigma_b = np.sqrt(var_b)
+
+    norm_cumsum = intensity_cumsum / intensity_cumsum[-1]
+    norm_cumsum = np.where(
+        norm_cumsum >= 1,
+        1 - negligible_value,
+        norm_cumsum
+    )
+    norm_cumsum = np.where(
+        norm_cumsum <= 0,
+        negligible_value,
+        norm_cumsum
+    )
+
+    minus_cumsum = 1 - norm_cumsum
+
+    prob_array = (
+        norm_cumsum * np.log(sigma_f)
+        + minus_cumsum * np.log(sigma_b)
+        - norm_cumsum * np.log(norm_cumsum)
+        - minus_cumsum * np.log(minus_cumsum)
+    )
+    prob_array[~np.isfinite(prob_array)] = np.inf
+
+    idx_threshold = int(np.argmin(prob_array))
+    threshold = float(intensity_bins[idx_threshold])
+
+    return threshold, idx_threshold, prob_array
 
 
 def determine_threshold(
@@ -1280,7 +1672,371 @@ def fill_threshold_with_gdal(threshold_array,
                              pol_list,
                              filled_value,
                              no_data=-50,
-                             average_tile=True):
+                             average_tile=True,
+                             smooth_sigma=0.75,
+                             resample_alg="bilinear",
+                             save_cog=True):
+    """
+    Fast deterministic threshold filling.
+
+    For average_tile=True:
+      1. Use the regular coarse threshold grid directly.
+      2. Fill NaNs on the coarse grid with deterministic nearest neighbor.
+      3. Optionally smooth the coarse grid.
+      4. Write coarse GeoTIFF.
+      5. Upsample to full image size with GDAL bilinear/cubic.
+
+    This avoids:
+      - scipy.griddata Delaunay platform differences
+      - sparse gdal_grid circular IDW artifacts
+      - slow CSV/VRT/gdal_grid path
+
+    Parameters
+    ----------
+    threshold_array : dict
+        Dictionary with keys 'array', 'block_row', 'block_col'.
+        For average_tile=True, array shape is [tau_row, tau_col, n_pol].
+    rows, cols : int
+        Full output raster size.
+    filename : str
+        Output base name, e.g. 'intensity_threshold_filled'.
+    outputdir : str
+        Scratch/output directory.
+    pol_list : list[str]
+        Polarizations.
+    filled_value : unused
+        Kept for API compatibility.
+    no_data : float
+        No-data value.
+    average_tile : bool
+        True for tile-averaged threshold grid.
+    smooth_sigma : float or None
+        Gaussian smoothing sigma in coarse-grid pixels.
+        Use None or 0 to disable.
+    resample_alg : str
+        'bilinear', 'cubic', or 'nearest'.
+    save_cog : bool
+        Whether to save final full-resolution raster as COG.
+        Set False for temporary delta rasters.
+    """
+
+    import os
+    import numpy as np
+    from osgeo import gdal
+    from scipy import ndimage, interpolate
+
+    def _fill_nan_nearest_regular_grid(z, no_data_value=-50):
+        """
+        Fill NaNs in a regular 2D grid using nearest valid cell.
+        Deterministic and fast.
+        """
+        z = np.asarray(z, dtype=np.float32).copy()
+        z[z == no_data_value] = np.nan
+
+        valid = np.isfinite(z)
+
+        if np.all(valid):
+            return z
+
+        if not np.any(valid):
+            return z
+
+        # distance_transform_edt returns indices of nearest valid cell
+        # when applied to invalid mask.
+        nearest_indices = ndimage.distance_transform_edt(
+            ~valid,
+            return_distances=False,
+            return_indices=True,
+        )
+
+        z_filled = z.copy()
+        z_filled[~valid] = z[
+            nearest_indices[0][~valid],
+            nearest_indices[1][~valid],
+        ]
+
+        return z_filled
+
+    def _smooth_only_if_requested(z, sigma):
+        """
+        Smooth the filled coarse grid.
+        """
+        if sigma is None or sigma <= 0:
+            return z.astype(np.float32)
+
+        return ndimage.gaussian_filter(
+            z.astype(np.float32),
+            sigma=float(sigma),
+            mode="nearest",
+        ).astype(np.float32)
+
+    def _write_geotiff(path, arr, geotransform, projection=""):
+        driver = gdal.GetDriverByName("GTiff")
+        ds = driver.Create(
+            path,
+            arr.shape[1],
+            arr.shape[0],
+            1,
+            gdal.GDT_Float32,
+            options=["COMPRESS=DEFLATE", "TILED=YES"],
+        )
+        ds.SetGeoTransform(geotransform)
+        if projection:
+            ds.SetProjection(projection)
+        band = ds.GetRasterBand(1)
+        band.WriteArray(arr.astype(np.float32))
+        band.SetNoDataValue(no_data)
+        ds.FlushCache()
+        ds = None
+
+    def _upsample_coarse_to_full(coarse_path, full_path, rows, cols, alg):
+        """
+        Upsample coarse raster to full image size using GDAL.
+        This replaces gdal_grid for average_tile=True.
+        """
+        src = gdal.Open(coarse_path, gdal.GA_ReadOnly)
+        if src is None:
+            raise RuntimeError(f"Cannot open coarse raster: {coarse_path}")
+
+        # Keep same coordinate extent as coarse raster, but force full pixel size.
+        gdal.Translate(
+            full_path,
+            src,
+            width=int(cols),
+            height=int(rows),
+            resampleAlg=alg,
+            outputType=gdal.GDT_Float32,
+            creationOptions=["COMPRESS=DEFLATE", "TILED=YES"],
+        )
+        src = None
+
+    if average_tile:
+        tau_row, tau_col, n_pol = threshold_array["array"].shape
+        block_row = threshold_array["block_row"]
+        block_col = threshold_array["block_col"]
+
+        # Coarse raster extent should match full image extent: x=[0, cols], y=[0, rows].
+        # Pixel size is approximately block_col/block_row.
+        #
+        # Use north-up geotransform with y decreasing.
+        coarse_gt = (
+            0.0,
+            float(cols) / float(tau_col),
+            0.0,
+            float(rows),
+            0.0,
+            -float(rows) / float(tau_row),
+        )
+
+        for polind, pol in enumerate(pol_list):
+            z = np.asarray(
+                threshold_array["array"][:, :, polind],
+                dtype=np.float32,
+            ).copy()
+
+            z[z == no_data] = np.nan
+
+            tif_file_str = os.path.join(outputdir, f"{filename}_{pol}.tif")
+            coarse_file_str = os.path.join(
+                outputdir,
+                f"{filename}_{pol}_coarse_tmp.tif",
+            )
+
+            if np.count_nonzero(np.isfinite(z)) > 1:
+                z_filled = _fill_nan_nearest_regular_grid(
+                    z,
+                    no_data_value=no_data,
+                )
+
+                z_filled = _smooth_only_if_requested(
+                    z_filled,
+                    smooth_sigma,
+                )
+
+                _write_geotiff(
+                    coarse_file_str,
+                    z_filled,
+                    coarse_gt,
+                    projection="",
+                )
+
+                _upsample_coarse_to_full(
+                    coarse_file_str,
+                    tif_file_str,
+                    rows=rows,
+                    cols=cols,
+                    alg=resample_alg,
+                )
+
+            elif np.count_nonzero(np.isfinite(z)) == 1:
+                value = float(z[np.isfinite(z)][0])
+                _dswx_sar_util.create_geotiff_with_one_value(
+                    tif_file_str,
+                    shape=[rows, cols],
+                    filled_value=value,
+                )
+
+            else:
+                logger.info(f"threshold array is empty for {pol}")
+
+                empty_data = np.ones((rows, cols), dtype=np.float32) * no_data
+
+                geotransform = (0.0, 1.0, 0.0, float(rows), 0.0, -1.0)
+                _write_geotiff(
+                    tif_file_str,
+                    empty_data,
+                    geotransform,
+                    projection="",
+                )
+
+            if save_cog:
+                _dswx_sar_util._save_as_cog(
+                    tif_file_str,
+                    outputdir,
+                    logger,
+                    compression="DEFLATE",
+                    nbits=16,
+                )
+
+            # Optional cleanup
+            try:
+                if os.path.exists(coarse_file_str):
+                    os.remove(coarse_file_str)
+            except Exception:
+                pass
+
+        return
+
+    # ------------------------------------------------------------------
+    # Fallback for average_tile=False.
+    # Keep original sparse-point path, but write dense regular grid first
+    # to reduce circular artifacts.
+    # ------------------------------------------------------------------
+    x_coarse_grid = np.arange(0, cols + 1, 400)
+    y_coarse_grid = np.arange(0, rows + 1, 400)
+    x_arr_tau, y_arr_tau = np.meshgrid(x_coarse_grid, y_coarse_grid)
+
+    for polind, pol in enumerate(pol_list):
+        z_tau = np.array(
+            threshold_array["array"][polind],
+            dtype=np.float32,
+            copy=True,
+        )
+        x_tau = np.array(
+            threshold_array["block_col"][polind],
+            dtype=np.float32,
+            copy=True,
+        )
+        y_tau = np.array(
+            threshold_array["block_row"][polind],
+            dtype=np.float32,
+            copy=True,
+        )
+
+        z_tau[z_tau == no_data] = np.nan
+        valid = np.isfinite(z_tau)
+
+        tif_file_str = os.path.join(outputdir, f"{filename}_{pol}.tif")
+        coarse_file_str = os.path.join(
+            outputdir,
+            f"{filename}_{pol}_coarse_tmp.tif",
+        )
+
+        if np.count_nonzero(valid) > 1:
+            # For scattered samples, linear griddata is still needed.
+            interp_tau = interpolate.griddata(
+                (x_tau[valid], y_tau[valid]),
+                z_tau[valid],
+                (x_arr_tau.flatten(), y_arr_tau.flatten()),
+                method="linear",
+            )
+
+            interp_tau = interp_tau.reshape(x_arr_tau.shape)
+
+            # Fill outside convex hull by nearest.
+            missing = ~np.isfinite(interp_tau)
+            if np.any(missing):
+                nearest_tau = interpolate.griddata(
+                    (x_tau[valid], y_tau[valid]),
+                    z_tau[valid],
+                    (x_arr_tau.flatten(), y_arr_tau.flatten()),
+                    method="nearest",
+                ).reshape(x_arr_tau.shape)
+
+                interp_tau[missing] = nearest_tau[missing]
+
+            interp_tau = _smooth_only_if_requested(
+                interp_tau,
+                smooth_sigma,
+            )
+
+            coarse_gt = (
+                0.0,
+                float(cols) / float(interp_tau.shape[1]),
+                0.0,
+                float(rows),
+                0.0,
+                -float(rows) / float(interp_tau.shape[0]),
+            )
+
+            _write_geotiff(
+                coarse_file_str,
+                interp_tau.astype(np.float32),
+                coarse_gt,
+                projection="",
+            )
+
+            _upsample_coarse_to_full(
+                coarse_file_str,
+                tif_file_str,
+                rows=rows,
+                cols=cols,
+                alg=resample_alg,
+            )
+
+        elif np.count_nonzero(valid) == 1:
+            _dswx_sar_util.create_geotiff_with_one_value(
+                tif_file_str,
+                shape=[rows, cols],
+                filled_value=float(z_tau[valid][0]),
+            )
+
+        else:
+            logger.info(f"threshold array is empty for {pol}")
+            empty_data = np.ones((rows, cols), dtype=np.float32) * no_data
+            geotransform = (0.0, 1.0, 0.0, float(rows), 0.0, -1.0)
+            _write_geotiff(
+                tif_file_str,
+                empty_data,
+                geotransform,
+                projection="",
+            )
+
+        if save_cog:
+            _dswx_sar_util._save_as_cog(
+                tif_file_str,
+                outputdir,
+                logger,
+                compression="DEFLATE",
+                nbits=16,
+            )
+
+        try:
+            if os.path.exists(coarse_file_str):
+                os.remove(coarse_file_str)
+        except Exception:
+            pass
+
+def fill_threshold_with_gdal_original(
+        threshold_array,
+        rows,
+        cols,
+        filename,
+        outputdir,
+        pol_list,
+        filled_value,
+        no_data=-50,
+        average_tile=True):
     """Interpolate thresholds over a 2-D grid.
 
     Parameters

--- a/src/dswx_sar/common/_refine_with_bimodality.py
+++ b/src/dswx_sar/common/_refine_with_bimodality.py
@@ -27,6 +27,8 @@ from dswx_sar.common._dswx_sar_util import (
 logger = logging.getLogger('dswx_sar')
 
 
+
+
 class BimodalityMetrics:
     '''Estimate metrics for bimodality'''
 
@@ -54,8 +56,14 @@ class BimodalityMetrics:
         """
         if gauss_dist_thres_bound is None:
             gauss_dist_thres_bound = [-18, 0]
-        self.intensity_array = intensity_array.flatten()
-        int_db = 10 * np.log10(self.intensity_array)
+        self.intensity_array = np.asarray(intensity_array, dtype=np.float32).flatten()
+
+        with np.errstate(divide="ignore", invalid="ignore"):
+            int_db = 10.0 * np.log10(self.intensity_array)
+
+        int_db = np.asarray(int_db, dtype=np.float32)
+        int_db = np.round(int_db, 3).astype(np.float64)
+
         self.int_db = int_db
 
         bins_hist = np.linspace(hist_min,
@@ -65,8 +73,9 @@ class BimodalityMetrics:
         self.counts, bins = np.histogram(int_db,
                                          bins=bins_hist,
                                          density=True)
-        self.bincenter = (bins[:-1] + bins[1:]) / 2
-        self.binstep = bins[2] - bins[1]
+        self.counts = np.asarray(self.counts, dtype=np.float64)
+        self.bincenter = np.asarray((bins[:-1] + bins[1:]) / 2, dtype=np.float64)
+        self.binstep = float(bins[2] - bins[1])
 
         # remove invalid values
         mask = (np.isnan(int_db)) | (np.isinf(int_db)) | (np.isinf(-int_db))
@@ -119,45 +128,158 @@ class BimodalityMetrics:
             amp_gt = self.prob[amp_gt_ind]
 
             try:
-                # starting value for curve_fit
-                # mean, std, amplitude, mean, std, amplitude
                 expected = (mean_lt, std_lt, amp_lt,
                             mean_gt, std_gt, amp_gt)
-                params, _ = curve_fit(self.bimodal,
-                                      self.bincenter,
-                                      self.prob,
-                                      expected,
-                                      bounds=(
-                                        (-30, 1e-10, 0,
-                                         -30, 1e-10, 0),
-                                        (5, 5, 1,
-                                         5, 5, 1)))
-                if params[0] > params[3]:
-                    self.second_mode = params[:3]
-                    self.first_mode = params[3:]
-                else:
-                    self.first_mode = params[:3]
-                    self.second_mode = params[3:]
-                # Left Gaussian
-                self.simul_first = self.gauss(self.bincenter,
-                                              *self.first_mode)
-                self.simul_second = self.gauss(self.bincenter,
-                                               *self.second_mode)
+
+                fit = self._fit_bimodal_deterministic(expected)
+
+                self.params = fit["params"]
+                self.first_mode = fit["first_mode"]
+                self.second_mode = fit["second_mode"]
+                self.fit_rss = fit["rss"]
+                self.fit_score = fit["score"]
+
+                self.simul_first = self.gauss(self.bincenter, *self.first_mode)
+                self.simul_second = self.gauss(self.bincenter, *self.second_mode)
                 self.simul_all = self.simul_first + self.simul_second
                 self.optimization = True
 
-            except ValueError:
-                logger.info('ValueError: Bimodal curve Fitting fails in '
-                            'BimodalityMetrics.')
-                self.optimization = False
-            except RuntimeError:
-                logger.info('RuntimeError: Bimodal curve Fitting fails in '
-                            'BimodalityMetrics.')
+            except Exception as e:
+                logger.info(f'Bimodal curve fitting fails in BimodalityMetrics: {e}')
                 self.optimization = False
         else:
             self.optimization = False
             self.enough_number = False
 
+        expected = (mean_lt, std_lt, amp_lt,
+            mean_gt, std_gt, amp_gt)
+        self.expected = expected
+
+    def _fit_bimodal_deterministic(self, expected):
+        """
+        Deterministic multi-start bimodal Gaussian fitting.
+
+        Keeps the original Chini/Gaussian-fit method, but avoids accepting
+        platform-dependent local minima from a single curve_fit call.
+        """
+
+        x = np.asarray(self.bincenter, dtype=np.float64)
+        y = np.asarray(self.prob, dtype=np.float64)
+
+        y = np.nan_to_num(y, nan=0.0, posinf=0.0, neginf=0.0)
+        y = np.round(y, 12).astype(np.float64)
+        x = np.round(x, 6).astype(np.float64)
+
+        # More physical bounds than 0~1 amplitude and sigma 1e-10~5.
+        lower = np.array([-30, 0.05, 1e-4,
+                        -30, 0.05, 1e-4], dtype=np.float64)
+        upper = np.array([5, 3.5, 0.50,
+                        5, 3.5, 0.50], dtype=np.float64)
+
+        expected = np.asarray(expected, dtype=np.float64)
+        expected = np.clip(expected, lower + 1e-6, upper - 1e-6)
+        expected = np.round(expected, 12)
+
+        # Deterministic alternative initial guesses.
+        # These are not random. Same input -> same p0 list.
+        p0_list = [expected]
+
+        try:
+            q10, q25, q50, q75, q90 = np.nanpercentile(self.int_db, [10, 25, 50, 75, 90])
+            amp_max = max(float(np.nanmax(y)), 1e-4)
+
+            p0_list.extend([
+                [q25, 0.5, amp_max * 0.5, q75, 0.5, amp_max * 0.5],
+                [q10, 0.8, amp_max * 0.4, q75, 0.8, amp_max * 0.4],
+                [q25, 1.0, amp_max * 0.4, q90, 1.0, amp_max * 0.4],
+                [q10, 1.5, amp_max * 0.3, q90, 1.5, amp_max * 0.3],
+                [q50 - 1.0, 0.7, amp_max * 0.4, q50 + 1.0, 0.7, amp_max * 0.4],
+            ])
+        except Exception:
+            pass
+
+        best = None
+
+        for p0 in p0_list:
+            p0 = np.asarray(p0, dtype=np.float64)
+            p0 = np.clip(p0, lower + 1e-6, upper - 1e-6)
+            p0 = np.round(p0, 12)
+
+            try:
+                with threadpool_limits(limits=1):
+                    params, _ = curve_fit(
+                        self.bimodal,
+                        x,
+                        y,
+                        p0=p0,
+                        bounds=(lower, upper),
+                        method="trf",
+                        max_nfev=20000,
+                        ftol=1e-10,
+                        xtol=1e-10,
+                        gtol=1e-10,
+                        x_scale="jac",
+                    )
+
+                params = np.asarray(params, dtype=np.float64)
+
+                if not np.all(np.isfinite(params)):
+                    continue
+
+                # Sort modes by mean.
+                if params[0] > params[3]:
+                    first = params[3:6]
+                    second = params[0:3]
+                else:
+                    first = params[0:3]
+                    second = params[3:6]
+
+                m1, s1, a1 = first
+                m2, s2, a2 = second
+                sep = abs(m2 - m1)
+
+                # Physical validity guard.
+                fit_valid = (
+                    0.05 <= s1 <= 3.5 and
+                    0.05 <= s2 <= 3.5 and
+                    1e-4 <= a1 <= 0.50 and
+                    1e-4 <= a2 <= 0.50 and
+                    0.3 <= sep <= 12.0
+                )
+
+                if not fit_valid:
+                    continue
+
+                residual = y - self.bimodal(x, *params)
+                rss = float(np.sum(residual ** 2))
+
+                # Canonical score:
+                # round RSS so tiny platform differences do not change winner.
+                rss_key = round(rss, 12)
+
+                # Tie-breaker prefers more balanced, narrower, ordered solution.
+                balance = abs(np.log((a1 + 1e-12) / (a2 + 1e-12)))
+                width_sum = s1 + s2
+                sep_key = -sep
+
+                score = (rss_key, round(balance, 6), round(width_sum, 6), round(sep_key, 6))
+
+                if best is None or score < best["score"]:
+                    best = {
+                        "params": params,
+                        "first_mode": first,
+                        "second_mode": second,
+                        "rss": rss,
+                        "score": score,
+                    }
+
+            except Exception:
+                continue
+
+        if best is None:
+            raise RuntimeError("All deterministic bimodal curve fits failed.")
+
+        return best
     def gauss(self, array, mu, sigma, amplitude):
         """ Calculate the value of a Gaussian (normal) function.
 
@@ -664,15 +786,67 @@ class BimodalityMetrics:
                 (ashman, bhc, surface_ratio,
                  bm_coeff, bc_coeff) = self.get_metric()
 
+                sigma_bound_hit = False
+                try:
+                    sigmas = [
+                        float(self.first_mode[1]),
+                        float(self.second_mode[1]),
+                    ]
+                    sigma_bound_hit = any(s >= 4.99 for s in sigmas)
+                except Exception:
+                    sigma_bound_hit = False
+
+
+                unstable_chini_fit = (
+                    (not np.isfinite(ashman)) or
+                    (not np.isfinite(surface_ratio)) or
+                    ((ashman > 10) and (surface_ratio < 0.01)) or
+                    sigma_bound_hit
+                )
+
+                if unstable_chini_fit:
+                    return False
+
+                degenerate_fit = (
+                    (not np.isfinite(ashman)) or
+                    (not np.isfinite(surface_ratio)) or
+                    (surface_ratio < 1e-6) or
+                    (ashman > 10) or
+                    sigma_bound_hit
+                )
+
+                if degenerate_fit:
+                    bt_max, ad_max = estimate_bimodality(self.int_db)
+
+                    bimodality_flag = (
+                        np.isfinite(bt_max) and
+                        np.isfinite(ad_max) and
+                        (bt_max > thresholds[3]) and
+                        (ad_max > thresholds[0])
+                    )
+
+                    return bool(bimodality_flag)
                 # Check if the data satisfies the conditions for bimodality
-                bm_coeff_bool = bm_flag and \
-                    (bm_coeff is None or bm_coeff > thresholds[3])
-                ashman_bool = ashman_flag and \
-                    (ashman is None or ashman > thresholds[0])
-                surface_ratio_bool = surface_ratio_flag and \
-                    (surface_ratio is None or surface_ratio > thresholds[2])
-                bc_coeff_bool = bc_flag and \
-                    (bc_coeff is None or bc_coeff > 5/9)
+                EPS_ASHMAN = 0.05
+                EPS_BM = 0.02
+                EPS_SURFACE = 0.02
+                EPS_BC = 0.01
+
+                bm_coeff_bool = bm_flag and (
+                    bm_coeff is not None and bm_coeff > thresholds[3] + EPS_BM
+                )
+
+                ashman_bool = ashman_flag and (
+                    ashman is not None and ashman > thresholds[0] + EPS_ASHMAN
+                )
+
+                surface_ratio_bool = surface_ratio_flag and (
+                    surface_ratio is not None and surface_ratio > thresholds[2] + EPS_SURFACE
+                )
+
+                bc_coeff_bool = bc_flag and (
+                    bc_coeff is not None and bc_coeff > 5 / 9 + EPS_BC
+                )
                 bimodal_metrics = (int(ashman_bool) +
                                    int(bm_coeff_bool) +
                                    int(bc_coeff_bool))

--- a/src/dswx_sar/defaults/algorithm_parameter_ni.yaml
+++ b/src/dswx_sar/defaults/algorithm_parameter_ni.yaml
@@ -239,14 +239,32 @@ runconfig:
             copol_threshold: -10
             line_per_block: 300
 
+            # Class-specific thresholds
+            tree_dual_pol_ratio_threshold: 8.0
+            tree_cross_pol_min: -13.0
+            tree_copol_threshold: -10.0
+
+            short_vegetation_dual_pol_ratio_threshold: 8.5
+            short_vegetation_cross_pol_min: -14.0
+            short_vegetation_copol_threshold: -12.0
+
             # If 'auto' is selected and GLAD is available, GLAD will be
             # used for inundated vegetation. In the 'auto' option,
             # GLAD is not provided, then WorldCover will be used to extract
             # the target areas.
             target_area_file_type: 'auto'
             target_worldcover_class: ['Herbaceous wetland', 'Tree Cover', 'Shrubs', 'Grassland', 'Mangrove', 'Moss and lichen', 'Crop']
-            target_glad_class: ['200-207', '125-148'] #['112-124', '200-207', '19-24', '125-148']
+            target_glad_class:
+                - 123-148
+                - 200-207
 
+            # New class split
+            target_glad_tree_class:
+                - 125-148
+
+            target_glad_short_vegetation_class:
+                - 123-124
+                - 200-207
             # Optional refinement for inundated vegetation using fuzzy logic
             # and region growing. Reference water is intentionally excluded.
             fuzzy_refinement:
@@ -260,7 +278,7 @@ runconfig:
 
                 # 'intersection' is conservative and reduces false positives.
                 # 'union' expands IV areas and may reduce omission errors.
-                combine_mode: intersection
+                combine_mode: union
 
                 # Dual-pol ratio fuzzy membership range in dB.
                 # The current hard IV threshold is 8 dB, so this makes
@@ -283,6 +301,14 @@ runconfig:
 
                 # Block size for IV fuzzy computation.
                 line_per_block: 300
+                cross_pol_fuzzy_mode: soft
+                cross_pol_weight: 0.5
+                cross_pol_soft_margin: 2.0
+            water_connectivity:
+                enabled: true
+                dz_max: 1.0
+                max_distance_pixels: 100
+                connectivity: 8
 
             filter:
                 enabled: True

--- a/src/dswx_sar/nisar/detect_inundated_vegetation.py
+++ b/src/dswx_sar/nisar/detect_inundated_vegetation.py
@@ -4,9 +4,11 @@ import mimetypes
 import os
 import time
 
-from dswx_sar.common import _filter_SAR, _generate_log
 import numpy as np
+from collections import deque
+from scipy import ndimage
 
+from dswx_sar.common import _filter_SAR, _generate_log
 from dswx_sar.common import _dswx_sar_util
 from dswx_sar.nisar.dswx_ni_runconfig import DSWX_NI_POL_DICT, _get_parser, RunConfig
 from dswx_sar.common import _detect_inundated_vegetation
@@ -40,61 +42,132 @@ def _compute_iv_fuzzy_value(
         slope_min,
         slope_max,
         hand_threshold,
+        tree_area=None,
+        short_vegetation_area=None,
+        water_connectivity=None,
+        cross_db=None,
+        tree_cross_pol_min=None,
+        short_vegetation_cross_pol_min=None,
+        cross_pol_fuzzy_mode='none',
+        cross_pol_soft_margin=2.0,
+        cross_pol_weight=0.3,
+        short_vegetation_water_connectivity_weight=0.5,
         fuzzy_mode='weighted_sum'):
     """Compute fuzzy score for inundated vegetation refinement.
 
-    This fuzzy value intentionally excludes reference water.
+    Tree pixels use SAR/topographic fuzzy logic.
+    Short vegetation pixels can additionally use DEM/open-water connectivity.
+
+    The optional cross-pol term is intended to reduce false positives during
+    fuzzy refinement. It should usually be applied as a soft penalty rather
+    than as a hard mask for omission-sensitive cases.
 
     Parameters
     ----------
-    ratio_db : np.ndarray
-        Filtered co-pol / cross-pol ratio in dB.
-    hand : np.ndarray
-        HAND raster block.
-    slope : np.ndarray
-        Slope raster block.
-    target_area : np.ndarray
-        Potential vegetation target mask. Positive values are valid.
-    no_data : np.ndarray
-        Boolean no-data mask.
-    ratio_min : float
-        Ratio value where IV membership starts increasing.
-    ratio_max : float
-        Ratio value where IV membership reaches high confidence.
-    hand_min, hand_max : float
-        HAND z-membership range. Lower HAND is more likely IV.
-    slope_min, slope_max : float
-        Slope z-membership range. Lower slope is more likely IV.
-    hand_threshold : float
-        Hard HAND cutoff.
-    fuzzy_mode : str
-        'weighted_sum' or 'product'.
-
-    Returns
-    -------
-    iv_fuzzy : np.ndarray
-        Float32 fuzzy score.
+    cross_pol_fuzzy_mode : {'none', 'soft', 'hard'}
+        'none': do not use cross-pol in fuzzy refinement.
+        'soft': multiply fuzzy score by ((1 - weight) + weight * cross_s).
+        'hard': set fuzzy score to 0 where cross-pol is below threshold.
+    cross_pol_soft_margin : float
+        Width in dB used by smf() above the cross-pol threshold.
+        For example, threshold=-26 and margin=2 gives membership transition
+        from -26 to -24 dB.
+    cross_pol_weight : float
+        Strength of the soft cross-pol penalty, 0-1.
+    short_vegetation_water_connectivity_weight : float
+        Strength of DEM/open-water connectivity penalty for short vegetation,
+        0-1. With 0.5, short_fuzzy = sar_fuzzy * (0.5 + 0.5 * water_conn_s).
     """
 
     ratio_db = np.asarray(ratio_db, dtype=np.float32)
     hand = np.asarray(hand, dtype=np.float32)
     slope = np.asarray(slope, dtype=np.float32)
 
-    # Higher dual-pol ratio is more likely inundated vegetation.
     ratio_s = smf(ratio_db, ratio_min, ratio_max)
-
-    # Lower HAND and lower slope are more likely valid wet/inundated areas.
     hand_z = zmf(hand, hand_min, hand_max)
     slope_z = zmf(slope, slope_min, slope_max)
 
     if fuzzy_mode == 'product':
-        iv_fuzzy = ratio_s * hand_z * slope_z
+        sar_fuzzy = ratio_s * hand_z * slope_z
     else:
-        iv_fuzzy = (
+        sar_fuzzy = (
             ratio_s * 0.5 +
             hand_z * 0.25 +
             slope_z * 0.25
         )
+
+    sar_fuzzy = np.asarray(sar_fuzzy, dtype=np.float32)
+
+    if tree_area is None:
+        tree_area = np.zeros_like(sar_fuzzy, dtype=bool)
+    else:
+        tree_area = np.asarray(tree_area).astype(bool)
+
+    if short_vegetation_area is None:
+        short_vegetation_area = np.zeros_like(sar_fuzzy, dtype=bool)
+    else:
+        short_vegetation_area = np.asarray(short_vegetation_area).astype(bool)
+
+    # Optional cross-pol false-positive suppression.
+    cross_pol_fuzzy_mode = str(cross_pol_fuzzy_mode).lower()
+    if cross_pol_fuzzy_mode not in ['none', 'soft', 'hard']:
+        raise ValueError(
+            f"Invalid cross_pol_fuzzy_mode: {cross_pol_fuzzy_mode}. "
+            "Expected 'none', 'soft', or 'hard'."
+        )
+
+    if cross_db is not None and cross_pol_fuzzy_mode != 'none':
+        cross_db = np.asarray(cross_db, dtype=np.float32)
+        cross_s = np.ones_like(sar_fuzzy, dtype=np.float32)
+
+        if tree_cross_pol_min is not None:
+            tree_cross_s = smf(
+                cross_db,
+                tree_cross_pol_min,
+                tree_cross_pol_min + cross_pol_soft_margin
+            )
+            cross_s[tree_area] = tree_cross_s[tree_area]
+
+        if short_vegetation_cross_pol_min is not None:
+            short_cross_s = smf(
+                cross_db,
+                short_vegetation_cross_pol_min,
+                short_vegetation_cross_pol_min + cross_pol_soft_margin
+            )
+            cross_s[short_vegetation_area] = short_cross_s[
+                short_vegetation_area]
+
+        cross_s[np.isnan(cross_s)] = 0
+        cross_s = np.clip(cross_s, 0, 1)
+
+        if cross_pol_fuzzy_mode == 'hard':
+            sar_fuzzy[cross_s <= 0] = 0
+        elif cross_pol_fuzzy_mode == 'soft':
+            cross_pol_weight = np.clip(cross_pol_weight, 0, 1)
+            sar_fuzzy *= ((1.0 - cross_pol_weight) +
+                          cross_pol_weight * cross_s)
+
+    if water_connectivity is None:
+        water_conn_s = np.zeros_like(sar_fuzzy, dtype=np.float32)
+    else:
+        water_conn_s = np.asarray(water_connectivity, dtype=np.float32)
+        water_conn_s[np.isnan(water_conn_s)] = 0
+        water_conn_s = np.clip(water_conn_s, 0, 1)
+
+    # Default: SAR/topography behavior.
+    iv_fuzzy = sar_fuzzy.copy()
+
+    # For short vegetation only, DEM/open-water connectivity boosts/suppresses
+    # the SAR fuzzy score. This avoids using DEM under trees.
+    short_weight = np.clip(short_vegetation_water_connectivity_weight, 0, 1)
+    short_fuzzy = sar_fuzzy * (
+        (1.0 - short_weight) + short_weight * water_conn_s
+    )
+
+    iv_fuzzy[short_vegetation_area] = short_fuzzy[short_vegetation_area]
+
+    # Tree pixels are intentionally left as SAR/topography fuzzy score.
+    iv_fuzzy[tree_area] = sar_fuzzy[tree_area]
 
     valid_area = (
         (target_area > 0) &
@@ -107,13 +180,432 @@ def _compute_iv_fuzzy_value(
 
     return iv_fuzzy.astype(np.float32)
 
+def _get_cfg_value(cfg_obj, name, default):
+    """Safely read config attribute."""
+    if cfg_obj is None:
+        return default
+    return getattr(cfg_obj, name, default)
+
+
+def _as_bool_mask(arr):
+    """Convert raster values to boolean mask."""
+    return np.asarray(arr) > 0
+
+
+
+def _compute_water_connectivity_from_open_water(
+        dem,
+        open_water,
+        no_data,
+        *,
+        dz_max=1.0,
+        max_distance_pixels=100,
+        barrier_mask=None,
+        connectivity=8,
+        min_component_pixels=5):
+    """DEM-constrained open-water connectivity.
+
+    Water level is estimated as the median DEM elevation of each
+    connected open-water component.
+    """
+
+    dem = np.asarray(dem, dtype=np.float32)
+    open_water = np.asarray(open_water).astype(bool)
+    no_data = np.asarray(no_data).astype(bool)
+
+    if barrier_mask is None:
+        barrier_mask = np.zeros_like(open_water, dtype=bool)
+    else:
+        barrier_mask = np.asarray(barrier_mask).astype(bool)
+
+    valid_seed = (
+        open_water &
+        np.isfinite(dem) &
+        (~no_data) &
+        (~barrier_mask)
+    )
+
+    if connectivity == 4:
+        structure = np.array([[0, 1, 0],
+                              [1, 1, 1],
+                              [0, 1, 0]], dtype=np.uint8)
+        neighbors = [(-1, 0), (1, 0), (0, -1), (0, 1)]
+    else:
+        structure = np.ones((3, 3), dtype=np.uint8)
+        neighbors = [
+            (-1, 0), (1, 0), (0, -1), (0, 1),
+            (-1, -1), (-1, 1), (1, -1), (1, 1)
+        ]
+
+    labels, nlabels = ndimage.label(valid_seed, structure=structure)
+
+    conn = np.zeros(open_water.shape, dtype=np.uint8)
+    dist = np.full(open_water.shape, np.inf, dtype=np.float32)
+    water_level = np.full(open_water.shape, np.nan, dtype=np.float32)
+
+    q = deque()
+
+    for label_id in range(1, nlabels + 1):
+        component = labels == label_id
+        n_component = np.sum(component)
+
+        if n_component < min_component_pixels:
+            continue
+
+        component_dem = dem[component]
+        component_dem = component_dem[np.isfinite(component_dem)]
+
+        if component_dem.size == 0:
+            continue
+
+        # Estimated local water level for this open-water object.
+        wl = np.nanmedian(component_dem).astype(np.float32)
+
+        ys, xs = np.where(component)
+        for y, x in zip(ys, xs):
+            conn[y, x] = 1
+            dist[y, x] = 0.0
+            water_level[y, x] = wl
+            q.append((y, x))
+
+    height, width = dem.shape
+
+    while q:
+        y, x = q.popleft()
+        wl = water_level[y, x]
+
+        for dy, dx in neighbors:
+            yy = y + dy
+            xx = x + dx
+
+            if yy < 0 or yy >= height or xx < 0 or xx >= width:
+                continue
+
+            if conn[yy, xx] == 1:
+                continue
+
+            if no_data[yy, xx] or barrier_mask[yy, xx]:
+                continue
+
+            if not np.isfinite(dem[yy, xx]):
+                continue
+
+            new_dist = dist[y, x] + np.hypot(dy, dx)
+            if new_dist > max_distance_pixels:
+                continue
+
+            # Stop growth if terrain is too high above the propagated
+            # component-level water surface.
+            if dem[yy, xx] > wl + dz_max:
+                continue
+
+            conn[yy, xx] = 1
+            dist[yy, xx] = new_dist
+            water_level[yy, xx] = wl
+            q.append((yy, xx))
+
+    water_conn_s = np.exp(-dist / max_distance_pixels).astype(np.float32)
+    water_conn_s[conn == 0] = 0.0
+    water_conn_s[open_water] = 1.0
+    water_conn_s[np.isnan(water_conn_s)] = 0.0
+
+    return water_conn_s, conn, dist, water_level
+
+
+def _build_short_vegetation_water_connectivity(
+        cfg,
+        pol_all_str,
+        im_meta,
+        short_vegetation_path,
+        no_data_raster_path):
+    """Build DEM/open-water connectivity fuzzy layer for short vegetation only."""
+
+    processing_cfg = cfg.groups.processing
+    scratch_dir = cfg.groups.product_path_group.scratch_path
+    inundated_vege_cfg = processing_cfg.inundated_vegetation
+    iv_fuzzy_cfg = getattr(inundated_vege_cfg, 'fuzzy_refinement', None)
+
+    dem_path = os.path.join(scratch_dir, 'interpolated_DEM.tif')
+
+    water_conn_cfg = getattr(iv_fuzzy_cfg, 'water_connectivity', None)
+
+    enabled = _get_cfg_value(water_conn_cfg, 'enabled', False)
+    if not enabled:
+        return None
+
+    open_water_path = os.path.join(
+        scratch_dir,
+        f'bimodality_output_binary_{pol_all_str}.tif'
+    )
+
+    if not os.path.exists(open_water_path):
+        logger.warning(
+            f'Open water map is not found: {open_water_path}. '
+            'DEM/open-water connectivity will not be used.'
+        )
+        return None
+
+    if not os.path.exists(dem_path):
+        logger.warning(
+            f'DEM is not found: {dem_path}. '
+            'DEM/open-water connectivity will not be used.'
+        )
+        return None
+
+    logger.info('Build DEM/open-water connectivity for short vegetation.')
+
+    dem = _dswx_sar_util.read_geotiff(dem_path)
+    open_water = _dswx_sar_util.read_geotiff(open_water_path)
+    short_veg = _dswx_sar_util.read_geotiff(short_vegetation_path)
+    no_data = _dswx_sar_util.read_geotiff(no_data_raster_path) == 1
+
+    open_water = _as_bool_mask(open_water)
+    short_veg = _as_bool_mask(short_veg)
+
+    # Keep open-water seeds, but final support is only for short vegetation.
+    water_conn_s, topo_valid, dist, water_level = (
+        _compute_fast_water_connectivity_from_open_water(
+            dem=dem,
+            open_water=open_water,
+            no_data=no_data,
+            max_distance_pixels=_get_cfg_value(
+                water_conn_cfg,
+                'max_distance_pixels',
+                100
+            ),
+            z_max=_get_cfg_value(
+                water_conn_cfg,
+                'z_max',
+                _get_cfg_value(water_conn_cfg, 'dz_max', 1.0)
+            ),
+            min_water_elevation=_get_cfg_value(
+                water_conn_cfg,
+                'min_water_elevation',
+                None
+            ),
+            max_water_elevation=_get_cfg_value(
+                water_conn_cfg,
+                'max_water_elevation',
+                None
+            )
+        )
+    )
+    water_conn_path = os.path.join(
+        scratch_dir,
+        f'temp_water_connectivity_{pol_all_str}.tif'
+    )
+
+    _dswx_sar_util.save_dswx_product(
+        water_conn_s,
+        water_conn_path,
+        geotransform=im_meta['geotransform'],
+        projection=im_meta['projection'],
+        scratch_dir=scratch_dir
+    )
+    water_level_path = os.path.join(
+        scratch_dir,
+        f'temp_water_level_{pol_all_str}.tif'
+    )
+
+    _dswx_sar_util.save_dswx_product(
+        water_level,
+        water_level_path,
+        geotransform=im_meta['geotransform'],
+        projection=im_meta['projection'],
+        scratch_dir=scratch_dir
+    )
+    # IMPORTANT:
+    # DEM-based support is used only for short vegetation.
+    water_conn_s[~short_veg] = 0.0
+    topo_valid[~short_veg] = False
+    water_conn_path = os.path.join(
+        scratch_dir,
+        f'temp_short_vegetation_water_connectivity_{pol_all_str}.tif'
+    )
+
+    _dswx_sar_util.save_dswx_product(
+        water_conn_s,
+        water_conn_path,
+        geotransform=im_meta['geotransform'],
+        projection=im_meta['projection'],
+        scratch_dir=scratch_dir
+    )
+    _dswx_sar_util.save_raster_gdal(
+        data=water_conn_s,
+        output_file=water_conn_path,
+        geotransform=im_meta['geotransform'],
+        projection=im_meta['projection'],
+        scratch_dir=scratch_dir,
+        datatype='float32')
+
+    topo_valid_path = os.path.join(
+        scratch_dir,
+        f'temp_topo_valid_{pol_all_str}.tif'
+    )
+
+    _dswx_sar_util.save_dswx_product(
+        topo_valid,
+        topo_valid_path,
+        geotransform=im_meta['geotransform'],
+        projection=im_meta['projection'],
+        scratch_dir=scratch_dir
+    )
+    if processing_cfg.debug_mode:
+        # _dswx_sar_util.save_dswx_product(
+        #     conn,
+        #     os.path.join(
+        #         scratch_dir,
+        #         f'temp_short_vegetation_water_connected_{pol_all_str}.tif'
+        #     ),
+        #     geotransform=im_meta['geotransform'],
+        #     projection=im_meta['projection'],
+        #     scratch_dir=scratch_dir
+        # )
+
+        _dswx_sar_util.save_dswx_product(
+            dist,
+            os.path.join(
+                scratch_dir,
+                f'temp_short_vegetation_distance_to_water_{pol_all_str}.tif'
+            ),
+            geotransform=im_meta['geotransform'],
+            projection=im_meta['projection'],
+            scratch_dir=scratch_dir
+        )
+
+        _dswx_sar_util.save_dswx_product(
+            water_level,
+            os.path.join(
+                scratch_dir,
+                f'temp_short_vegetation_propagated_water_level_{pol_all_str}.tif'
+            ),
+            geotransform=im_meta['geotransform'],
+            projection=im_meta['projection'],
+            scratch_dir=scratch_dir
+        )
+
+    logger.info('Finished DEM/open-water connectivity for short vegetation.')
+
+    return water_conn_path
+
+
+from scipy import ndimage
+import numpy as np
+
+
+def _compute_fast_water_connectivity_from_open_water(
+        dem,
+        open_water,
+        no_data,
+        *,
+        max_distance_pixels=100,
+        z_max=1.0,
+        min_water_elevation=None,
+        max_water_elevation=None):
+    """Fast DEM/open-water topographic plausibility layer.
+
+    This creates a water-connectivity/topographic-support fuzzy layer by:
+    1. finding pixels within max_distance_pixels from open water,
+    2. assigning each nearby pixel the DEM elevation of its nearest
+       open-water pixel,
+    3. testing whether DEM <= nearest_water_elevation + z_max.
+
+    This is much faster than queue-based region growing.
+
+    Parameters
+    ----------
+    dem : np.ndarray
+        DEM in meters.
+    open_water : np.ndarray
+        Boolean open-water mask.
+    no_data : np.ndarray
+        Boolean no-data mask.
+    max_distance_pixels : int
+        Maximum distance from open water in pixels.
+    z_max : float
+        Allowed elevation above nearby water level, in meters.
+    min_water_elevation, max_water_elevation : float or None
+        Optional filters to remove unrealistic water DEM values.
+
+    Returns
+    -------
+    water_conn_s : np.ndarray
+        Float32 fuzzy support layer, 0-1.
+    topo_valid : np.ndarray
+        Boolean topographically plausible area.
+    distance : np.ndarray
+        Distance to nearest open water, in pixels.
+    nearest_water_level : np.ndarray
+        DEM elevation of nearest open-water pixel.
+    """
+
+    dem = np.asarray(dem, dtype=np.float32)
+    open_water = np.asarray(open_water).astype(bool)
+    no_data = np.asarray(no_data).astype(bool)
+
+    valid_water = (
+        open_water &
+        np.isfinite(dem) &
+        (~no_data)
+    )
+
+    if min_water_elevation is not None:
+        valid_water &= dem >= min_water_elevation
+
+    if max_water_elevation is not None:
+        valid_water &= dem <= max_water_elevation
+
+    if np.sum(valid_water) == 0:
+        shape = dem.shape
+        return (
+            np.zeros(shape, dtype=np.float32),
+            np.zeros(shape, dtype=bool),
+            np.full(shape, np.inf, dtype=np.float32),
+            np.full(shape, np.nan, dtype=np.float32)
+        )
+
+    # distance_transform_edt computes distance to zeros.
+    # Therefore use ~valid_water so valid water pixels are zeros.
+    distance, indices = ndimage.distance_transform_edt(
+        ~valid_water,
+        return_indices=True
+    )
+
+    distance = distance.astype(np.float32)
+
+    nearest_water_level = dem[tuple(indices)].astype(np.float32)
+
+    near_water = distance <= max_distance_pixels
+
+    topo_valid = (
+        near_water &
+        np.isfinite(dem) &
+        np.isfinite(nearest_water_level) &
+        (~no_data) &
+        (dem <= nearest_water_level + z_max)
+    )
+
+    # Fuzzy distance decay.
+    # Near open water gets high support; farther pixels get lower support.
+    water_conn_s = np.exp(-distance / max_distance_pixels).astype(np.float32)
+
+    # Keep only topographically valid nearby pixels.
+    water_conn_s[~topo_valid] = 0.0
+    water_conn_s[valid_water] = 1.0
+    water_conn_s[np.isnan(water_conn_s)] = 0.0
+
+    return water_conn_s, topo_valid, distance, nearest_water_level
+
 
 def _refine_inundated_vegetation_with_fuzzy_region_growing(
         cfg,
         pol_all_str,
         ratio_db_path,
+        cross_db_path,
         inundated_vege_path,
         target_area_path,
+        tree_area_path,
+        short_vegetation_area_path,
         im_meta):
     """Refine inundated vegetation using IV fuzzy logic and region growing."""
 
@@ -138,19 +630,6 @@ def _refine_inundated_vegetation_with_fuzzy_region_growing(
 
     logger.info('Start IV fuzzy refinement with region growing.')
 
-    dem_path = os.path.join(scratch_dir, 'interpolated_DEM.tif')
-    hand_path = os.path.join(scratch_dir, 'interpolated_hand.tif')
-    slope_path = os.path.join(scratch_dir, 'slope.tif')
-    no_data_raster_path = os.path.join(
-        scratch_dir,
-        f'no_data_area_{pol_all_str}.tif'
-    )
-    if not os.path.exists(slope_path):
-        create_slope_angle_geotiff(
-            dem_path,
-            slope_path,
-            lines_per_block=lines_per_block
-        )
     iv_fuzzy_path = os.path.join(
         scratch_dir,
         f'fuzzy_inundated_vegetation_{pol_all_str}.tif'
@@ -169,7 +648,20 @@ def _refine_inundated_vegetation_with_fuzzy_region_growing(
         'line_per_block',
         inundated_vege_cfg.line_per_block
     )
+    dem_path = os.path.join(scratch_dir, 'interpolated_DEM.tif')
+    hand_path = os.path.join(scratch_dir, 'interpolated_hand.tif')
+    slope_path = os.path.join(scratch_dir, 'slope.tif')
+    no_data_raster_path = os.path.join(
+        scratch_dir,
+        f'no_data_area_{pol_all_str}.tif'
+    )
 
+    if not os.path.exists(slope_path):
+        create_slope_angle_geotiff(
+            dem_path,
+            slope_path,
+            lines_per_block=lines_per_block
+        )
     ratio_min = getattr(
         iv_fuzzy_cfg,
         'ratio_member_min',
@@ -214,6 +706,50 @@ def _refine_inundated_vegetation_with_fuzzy_region_growing(
         'weighted_sum'
     )
 
+    # Optional cross-pol term inside fuzzy refinement.
+    # This is useful for testing whether cross-pol suppresses false positives.
+    cross_pol_fuzzy_mode = getattr(
+        iv_fuzzy_cfg,
+        'cross_pol_fuzzy_mode',
+        'none'
+    )
+    cross_pol_soft_margin = getattr(
+        iv_fuzzy_cfg,
+        'cross_pol_soft_margin',
+        2.0
+    )
+    cross_pol_weight = getattr(
+        iv_fuzzy_cfg,
+        'cross_pol_weight',
+        0.3
+    )
+
+    tree_cross_pol_min = getattr(
+        inundated_vege_cfg,
+        'tree_cross_pol_min',
+        inundated_vege_cfg.cross_pol_min
+    )
+    short_vegetation_cross_pol_min = getattr(
+        inundated_vege_cfg,
+        'short_vegetation_cross_pol_min',
+        inundated_vege_cfg.cross_pol_min
+    )
+
+    water_conn_cfg = getattr(iv_fuzzy_cfg, 'water_connectivity', None)
+    short_vegetation_water_connectivity_weight = _get_cfg_value(
+        water_conn_cfg,
+        'weight',
+        0.5
+    )
+
+    water_connectivity_path = _build_short_vegetation_water_connectivity(
+        cfg=cfg,
+        pol_all_str=pol_all_str,
+        im_meta=im_meta,
+        short_vegetation_path=short_vegetation_area_path,
+        no_data_raster_path=no_data_raster_path
+    )
+
     block_params = _dswx_sar_util.block_param_generator(
         lines_per_block=lines_per_block,
         data_shape=(im_meta['length'], im_meta['width']),
@@ -225,6 +761,11 @@ def _refine_inundated_vegetation_with_fuzzy_region_growing(
 
         ratio_db = _dswx_sar_util.get_raster_block(
             ratio_db_path,
+            block_param
+        )
+
+        cross_db = _dswx_sar_util.get_raster_block(
+            cross_db_path,
             block_param
         )
 
@@ -242,7 +783,23 @@ def _refine_inundated_vegetation_with_fuzzy_region_growing(
             target_area_path,
             block_param
         )
+        tree_area = _dswx_sar_util.get_raster_block(
+            tree_area_path,
+            block_param
+        ) > 0
 
+        short_vegetation_area = _dswx_sar_util.get_raster_block(
+            short_vegetation_area_path,
+            block_param
+        ) > 0
+
+        if water_connectivity_path is not None:
+            water_connectivity = _dswx_sar_util.get_raster_block(
+                water_connectivity_path,
+                block_param
+            )
+        else:
+            water_connectivity = None
         no_data = _dswx_sar_util.get_raster_block(
             no_data_raster_path,
             block_param
@@ -261,6 +818,17 @@ def _refine_inundated_vegetation_with_fuzzy_region_growing(
             slope_min=slope_min,
             slope_max=slope_max,
             hand_threshold=hand_threshold,
+            tree_area=tree_area,
+            short_vegetation_area=short_vegetation_area,
+            water_connectivity=water_connectivity,
+            cross_db=cross_db,
+            tree_cross_pol_min=tree_cross_pol_min,
+            short_vegetation_cross_pol_min=short_vegetation_cross_pol_min,
+            cross_pol_fuzzy_mode=cross_pol_fuzzy_mode,
+            cross_pol_soft_margin=cross_pol_soft_margin,
+            cross_pol_weight=cross_pol_weight,
+            short_vegetation_water_connectivity_weight=(
+                short_vegetation_water_connectivity_weight),
             fuzzy_mode=fuzzy_mode
         )
 
@@ -386,6 +954,53 @@ def run(cfg):
     target_worldcover_class = inundated_vege_cfg.target_worldcover_class
     target_glad_class = inundated_vege_cfg.target_glad_class
 
+
+    target_glad_tree_class = getattr(
+        inundated_vege_cfg,
+        'target_glad_tree_class',
+        []
+    )
+    target_glad_short_vegetation_class = getattr(
+        inundated_vege_cfg,
+        'target_glad_short_vegetation_class',
+        []
+    )
+
+    # Class-specific IV thresholds.
+    # If not configured, fall back to the original values.
+    tree_ratio_threshold = getattr(
+        inundated_vege_cfg,
+        'tree_dual_pol_ratio_threshold',
+        inundated_vege_ratio_threshold
+    )
+    short_veg_ratio_threshold = getattr(
+        inundated_vege_cfg,
+        'short_vegetation_dual_pol_ratio_threshold',
+        inundated_vege_ratio_threshold
+    )
+
+    tree_cross_pol_min = getattr(
+        inundated_vege_cfg,
+        'tree_cross_pol_min',
+        inundated_vege_cross_pol_min
+    )
+    short_veg_cross_pol_min = getattr(
+        inundated_vege_cfg,
+        'short_vegetation_cross_pol_min',
+        inundated_vege_cross_pol_min
+    )
+
+    tree_copol_threshold = getattr(
+        inundated_vege_cfg,
+        'tree_copol_threshold',
+        inundated_vege_copol_threshold
+    )
+    short_veg_copol_threshold = getattr(
+        inundated_vege_cfg,
+        'short_vegetation_copol_threshold',
+        inundated_vege_copol_threshold
+    )
+
     line_per_block = inundated_vege_cfg.line_per_block
     filter_options = inundated_vege_cfg.filter
     filter_method = inundated_vege_cfg.filter.method
@@ -398,7 +1013,19 @@ def run(cfg):
     interp_glad_path_str = os.path.join(scratch_dir, 'interpolated_glad.tif')
     interp_worldcover_path_str = os.path.join(scratch_dir,
                                               'interpolated_landcover.tif')
-
+    logger.info(f"dual_pol_ratio_threshold: {inundated_vege_ratio_threshold}")
+    logger.info(f"dual_pol_ratio_min: {inundated_vege_ratio_min}")
+    logger.info(f"dual_pol_ratio_max: {inundated_vege_ratio_max}")
+    logger.info(f"cross_pol_min: {inundated_vege_cross_pol_min}")
+    logger.info(f"copol_threshold: {inundated_vege_copol_threshold}")
+    logger.info(f"filter_method: {filter_method}")
+    logger.info(f"filter_options: {filter_options}")
+    logger.info(f"tree_ratio_threshold: {tree_ratio_threshold}")
+    logger.info(f"short_veg_ratio_threshold: {short_veg_ratio_threshold}")
+    logger.info(f"tree_cross_pol_min: {tree_cross_pol_min}")
+    logger.info(f"short_veg_cross_pol_min: {short_veg_cross_pol_min}")
+    logger.info(f"tree_copol_threshold: {tree_copol_threshold}")
+    logger.info(f"short_veg_copol_threshold: {short_veg_copol_threshold}")
     if target_file_type == 'auto':
         if os.path.exists(interp_glad_path_str):
             target_file_type = 'GLAD'
@@ -425,6 +1052,15 @@ def run(cfg):
         scratch_dir,
         f'temp_intensity_db_ratio_{pol_all_str}.tif'
     )
+    cross_db_path = os.path.join(
+        scratch_dir,
+        f'temp_crosspol_db_{pol_all_str}.tif'
+    )
+
+    tree_area_path = \
+        f"{scratch_dir}/temp_tree_area_{pol_all_str}.tif"
+    short_vegetation_area_path = \
+        f"{scratch_dir}/temp_short_vegetation_area_{pol_all_str}.tif"
 
     dual_pol_flag = False
     if (('HH' in pol_list) and ('HV' in pol_list)) or \
@@ -454,10 +1090,15 @@ def run(cfg):
         err_str = f'{rtc_dual_path} is not found.'
         raise FileExistsError(err_str)
 
-    if (inundated_vege_ratio_min > inundated_vege_ratio_threshold) or \
-       (inundated_vege_ratio_max < inundated_vege_ratio_threshold):
-        err_str = f'{inundated_vege_ratio_threshold} is not valid.'
-        raise ValueError(err_str)
+    for thr_name, thr_value in [
+            ('dual_pol_ratio_threshold', inundated_vege_ratio_threshold),
+            ('tree_dual_pol_ratio_threshold', tree_ratio_threshold),
+            ('short_vegetation_dual_pol_ratio_threshold',
+             short_veg_ratio_threshold)]:
+        if (inundated_vege_ratio_min > thr_value) or \
+           (inundated_vege_ratio_max < thr_value):
+            err_str = f'{thr_name}={thr_value} is not valid.'
+            raise ValueError(err_str)
 
     im_meta = _dswx_sar_util.get_meta_from_tif(rtc_dual_path)
 
@@ -517,6 +1158,17 @@ def run(cfg):
             scratch_dir=scratch_dir
         )
 
+        _dswx_sar_util.write_raster_block(
+            out_raster=cross_db_path,
+            data=cross_db,
+            block_param=block_param,
+            geotransform=im_meta['geotransform'],
+            projection=im_meta['projection'],
+            datatype='float32',
+            cog_flag=True,
+            scratch_dir=scratch_dir
+        )
+
         output_data = np.zeros(filt_ratio.shape, dtype='uint8')
 
         target_cross_pol = cross_db > inundated_vege_cross_pol_min
@@ -525,36 +1177,132 @@ def run(cfg):
             target_inundated_vege_class = mask_obj.get_mask(
                 mask_label=target_worldcover_class,
                 block_param=block_param)
+
+            # WorldCover fallback:
+            # if tree/short classes are not available, treat all target
+            # vegetation as tree-like existing behavior.
+            target_tree_class = np.array(
+                target_inundated_vege_class,
+                dtype=bool
+            )
+            target_short_vegetation_class = np.zeros_like(
+                target_tree_class,
+                dtype=bool
+            )
         elif target_file_type == 'GLAD':
-            inundated_vege_target = _detect_inundated_vegetation.parse_ranges(target_glad_class)
+            inundated_vege_target = (
+                _detect_inundated_vegetation.parse_ranges(target_glad_class)
+            )
+
             target_inundated_vege_class = mask_obj.get_mask(
                 mask_label=inundated_vege_target,
                 block_param=block_param)
 
-            # GLAD has no-data values for small island and polar regions
-            # such as Greenland. The WorldCover will be alternatively used
-            # for the no-data areas.
+            tree_target = (
+                _detect_inundated_vegetation.parse_ranges(
+                    target_glad_tree_class
+                )
+                if len(target_glad_tree_class) > 0 else []
+            )
+
+            short_veg_target = (
+                _detect_inundated_vegetation.parse_ranges(
+                    target_glad_short_vegetation_class
+                )
+                if len(target_glad_short_vegetation_class) > 0 else []
+            )
+
+            if len(tree_target) > 0:
+                target_tree_class = mask_obj.get_mask(
+                    mask_label=tree_target,
+                    block_param=block_param)
+            else:
+                target_tree_class = np.zeros_like(
+                    target_inundated_vege_class,
+                    dtype=bool
+                )
+
+            if len(short_veg_target) > 0:
+                target_short_vegetation_class = mask_obj.get_mask(
+                    mask_label=short_veg_target,
+                    block_param=block_param)
+            else:
+                target_short_vegetation_class = np.zeros_like(
+                    target_inundated_vege_class,
+                    dtype=bool
+                )
+
+            # If no tree/short split is configured, preserve old behavior.
+            if (len(tree_target) == 0) and (len(short_veg_target) == 0):
+                target_tree_class = np.array(
+                    target_inundated_vege_class,
+                    dtype=bool
+                )
+                target_short_vegetation_class = np.zeros_like(
+                    target_tree_class,
+                    dtype=bool
+                )
+
+            # GLAD has no-data values for small island and polar regions.
             glad_no_data = mask_obj.get_mask(
                 mask_label=[255],
                 block_param=block_param)
             logger.info(f'GLAD has {np.sum(glad_no_data)} no data')
+
             target_replace_class = sup_mask_obj.get_mask(
                 mask_label=target_worldcover_class,
                 block_param=block_param)
-            target_inundated_vege_class = np.array(target_inundated_vege_class,
-                                                   dtype='int8')
+
+            target_inundated_vege_class = np.array(
+                target_inundated_vege_class,
+                dtype='int8'
+            )
+
             target_inundated_vege_class[
                 glad_no_data & target_replace_class] = 2
-                # target_replace_class[glad_no_data]
+
+            # For GLAD no-data fallback, assign fallback vegetation to tree
+            # to preserve the original behavior and avoid applying DEM method
+            # where GLAD short vegetation is unknown.
+            target_tree_class = np.asarray(target_tree_class).astype(bool)
+            target_short_vegetation_class = np.asarray(
+                target_short_vegetation_class
+            ).astype(bool)
+
+            target_tree_class[glad_no_data & target_replace_class] = True
+            target_short_vegetation_class[
+                glad_no_data & target_replace_class
+            ] = False
 
         no_data = np.isnan(filt_ratio)
         target_inundated_vege_class[no_data] = 0
+        target_tree_class[no_data] = False
+        target_short_vegetation_class[no_data] = False
 
-        all_inundated_cand = \
-            (filt_ratio_db > inundated_vege_ratio_threshold) & \
-            target_cross_pol & target_co_pol 
-        inundated_vegetation = all_inundated_cand & \
+        tree_inundated_cand = (
+            (filt_ratio_db > tree_ratio_threshold) &
+            (cross_db > tree_cross_pol_min) &
+            (co_db > tree_copol_threshold) &
+            target_tree_class
+        )
+
+        short_vegetation_inundated_cand = (
+            (filt_ratio_db > short_veg_ratio_threshold) &
+            (cross_db > short_veg_cross_pol_min) &
+            (co_db > short_veg_copol_threshold) &
+            target_short_vegetation_class
+        )
+
+
+        all_inundated_cand = (
+            tree_inundated_cand |
+            short_vegetation_inundated_cand
+        )
+
+        inundated_vegetation = (
+            all_inundated_cand &
             (target_inundated_vege_class > 0)
+        )
         output_data[inundated_vegetation] = 2
 
         _dswx_sar_util.write_raster_block(
@@ -586,7 +1334,25 @@ def run(cfg):
             datatype='byte',
             cog_flag=True,
             scratch_dir=scratch_dir)
+        _dswx_sar_util.write_raster_block(
+            out_raster=tree_area_path,
+            data=target_tree_class.astype(np.uint8),
+            block_param=block_param,
+            geotransform=im_meta['geotransform'],
+            projection=im_meta['projection'],
+            datatype='byte',
+            cog_flag=True,
+            scratch_dir=scratch_dir)
 
+        _dswx_sar_util.write_raster_block(
+            out_raster=short_vegetation_area_path,
+            data=target_short_vegetation_class.astype(np.uint8),
+            block_param=block_param,
+            geotransform=im_meta['geotransform'],
+            projection=im_meta['projection'],
+            datatype='byte',
+            cog_flag=True,
+            scratch_dir=scratch_dir)
         if processing_cfg.debug_mode:
 
             _dswx_sar_util.write_raster_block(
@@ -605,8 +1371,11 @@ def run(cfg):
             cfg=cfg,
             pol_all_str=pol_all_str,
             ratio_db_path=ratio_db_path,
+            cross_db_path=cross_db_path,
             inundated_vege_path=inundated_vege_path,
             target_area_path=target_area_path,
+            tree_area_path=tree_area_path,
+            short_vegetation_area_path=short_vegetation_area_path,
             im_meta=im_meta
         )
     t_time_end = time.time()

--- a/src/dswx_sar/nisar/fuzzy_value_computation.py
+++ b/src/dswx_sar/nisar/fuzzy_value_computation.py
@@ -30,6 +30,40 @@ PIXEL_RESOLUTION_X = 30  # Replace with appropriate value
 PIXEL_RESOLUTION_Y = 30  # Replace with appropriate value
 RAD_TO_DEG = 180 / np.pi
 
+FUZZY_VALUE_QUANT = 1.0e-3
+INTENSITY_DB_QUANT = 1.0e-3
+THRESHOLD_DB_QUANT = 1.0e-2
+COMPARE_EPS_DB = 1.0e-6
+
+
+def _round_float(a, q):
+    a = np.asarray(a, dtype=np.float32)
+    out = np.array(a, dtype=np.float32, copy=True)
+    valid = np.isfinite(out)
+    out[valid] = np.round(out[valid] / q) * q
+    return out.astype(np.float32)
+
+
+def _lt_eps(a, b, eps=COMPARE_EPS_DB):
+    # Stable version of a < b
+    return a < (b - eps)
+
+
+def _gt_eps(a, b, eps=COMPARE_EPS_DB):
+    # Stable version of a > b
+    return a > (b + eps)
+
+
+def _ge_eps(a, b, eps=COMPARE_EPS_DB):
+    # Stable version of a >= b
+    return a >= (b - eps)
+
+
+def _le_eps(a, b, eps=COMPARE_EPS_DB):
+    # Stable version of a <= b
+    return a <= (b + eps)
+
+
 def zmf_recenter(values, peak, valley, alpha=1.0, min_width=1e-3):
     """
     Make zmf(. , minv=peak, maxv=adj_maxv) such that membership == 0.5 at
@@ -145,7 +179,15 @@ def compute_fuzzy_value(intensity,
             thresh_valley_str, block_param)
         peak_threshold_raster = _dswx_sar_util.get_raster_block(
             thresh_peak_str, block_param)
+        valley_threshold_raster = _round_float(
+            valley_threshold_raster,
+            THRESHOLD_DB_QUANT,
+        )
 
+        peak_threshold_raster = _round_float(
+            peak_threshold_raster,
+            THRESHOLD_DB_QUANT,
+        )
         intensity_band = intensity[int_id, :, :]
 
         # Fuzzy membership computation from intensity
@@ -157,19 +199,31 @@ def compute_fuzzy_value(intensity,
             peak_threshold_raster,
             valley_threshold_raster,
             alpha=fuzzy_option['intensity_mid_alpha'])
-
+        temp = _round_float(temp, FUZZY_VALUE_QUANT)
         intensity_z_set.append(temp)
 
-        intensity_mask_peak = intensity_band < peak_threshold_raster
+        intensity_mask_peak = _lt_eps(
+            intensity_band,
+            peak_threshold_raster,
+            eps=COMPARE_EPS_DB,
+        )
         initial_map[intensity_mask_peak == 0] = 0
 
         if pol in ['VH', 'HV']:
             pol_threshold = fuzzy_option['dark_area_land']
             water_threshold = fuzzy_option['dark_area_water']
-            low_backscatter = (intensity[int_id, :, :] < pol_threshold)
+            low_backscatter = _lt_eps(
+                intensity[int_id, :, :],
+                pol_threshold,
+                eps=COMPARE_EPS_DB,
+            )
             # Low backscattering candidates
             low_backscatter_cand &= low_backscatter
-            dark_water_cand &= intensity[int_id, :, :] < water_threshold
+            dark_water_cand &= _lt_eps(
+                intensity[int_id, :, :],
+                water_threshold,
+                eps=COMPARE_EPS_DB,
+            )
 
     intensity_z_set = np.array(intensity_z_set)
 
@@ -185,15 +239,32 @@ def compute_fuzzy_value(intensity,
         (landcover == landcover_label['Grassland']) | \
         (landcover == landcover_label['Herbaceous wetland'])
 
-    landcover_flat_area = (landcover_flat_area_cand) & \
-                          (slope < 5) & \
-                          (low_backscatter_cand)
-    high_frequent_water = \
-        (reference_water > fuzzy_option['high_frequent_water_min']) & \
-        (reference_water < fuzzy_option['high_frequent_water_max']) & \
-        (low_backscatter_cand)
-    dark_water = (dark_water_cand) & \
-                 (reference_water >= fuzzy_option['high_frequent_water_max'])
+    landcover_flat_area = (
+        landcover_flat_area_cand
+        & _lt_eps(slope, 5.0, eps=1.0e-6)
+        & low_backscatter_cand
+    )
+    high_frequent_water = (
+        _gt_eps(
+            reference_water,
+            fuzzy_option['high_frequent_water_min'],
+            eps=1.0e-6,
+        )
+        & _lt_eps(
+            reference_water,
+            fuzzy_option['high_frequent_water_max'],
+            eps=1.0e-6,
+        )
+        & low_backscatter_cand
+    )
+    dark_water = (
+        dark_water_cand
+        & _ge_eps(
+            reference_water,
+            fuzzy_option['high_frequent_water_max'],
+            eps=1.0e-6,
+        )
+    )
 
     co_pol_ind = []
     cross_pol_ind = []
@@ -234,27 +305,45 @@ def compute_fuzzy_value(intensity,
     nanmean_intensity_z_set = np.nanmean(intensity_z_set, axis=0)
 
     # Compute HAND membership
+    hand = np.asarray(hand, dtype=np.float32)
     hand[np.isnan(hand)] = 0
-    hand_z = zmf(hand, fuzzy_option['hand_min'], fuzzy_option['hand_max'])
 
+    # Optional: stabilize HAND input itself
+    hand = np.round(hand / 0.001) * 0.001
+
+    hand_z = zmf(
+        hand,
+        fuzzy_option['hand_min'],
+        fuzzy_option['hand_max']
+    )
+
+    # Stabilize fuzzy HAND membership
+    hand_z = np.asarray(hand_z, dtype=np.float32)
+    hand_z = np.round(hand_z / 0.001) * 0.001
+    hand_z = np.clip(hand_z, 0.0, 1.0).astype(np.float32)
+    hand_z = _round_float(hand_z, FUZZY_VALUE_QUANT)
     # compute slope membership
     slope_z = zmf(slope,
                   fuzzy_option['slope_min'],
                   fuzzy_option['slope_max'])
-
+    slope_z = _round_float(slope_z, FUZZY_VALUE_QUANT)
     # Compute area membership
-    handem = hand < fuzzy_option['hand_threshold']
+    handem = _lt_eps(
+        hand,
+        fuzzy_option['hand_threshold'],
+        eps=1.0e-6,
+    )
     wbsmask = (initial_map == 1) & (handem)
     watermap = calculate_water_area(wbsmask)
     area_s = smf(watermap,
                  fuzzy_option['area_min'],
                  fuzzy_option['area_max'])
-
+    area_s = _round_float(area_s, FUZZY_VALUE_QUANT)
     # Reference water map membership
     reference_water_s = smf(reference_water,
                             fuzzy_option['reference_water_min'],
                             fuzzy_option['reference_water_max'])
-
+    reference_water_s = _round_float(reference_water_s, FUZZY_VALUE_QUANT)
     # Compute fuzzy-logic-based value
     # The Opera dswx s1 algorithm calculates fuzzy-logic-based values based on
     # input parameters, including intensity, hand, slope, and reference water.
@@ -277,7 +366,7 @@ def compute_fuzzy_value(intensity,
                           (hand_z + slope_z + area_s) / 3 * 0.5)
     }
     avgvalue = method_dict[workflow]()
-
+    avgvalue = _round_float(avgvalue, FUZZY_VALUE_QUANT)
     return avgvalue, intensity_z_set, hand_z, \
         slope_z, area_s, reference_water_s, copol_only
 
@@ -404,12 +493,15 @@ def run(cfg):
         # Compute slope angle from DEM
         slope = _dswx_sar_util.get_raster_block(
             slope_gdal_str, block_param)
+        with np.errstate(divide='ignore', invalid='ignore'):
+            intensity_db = 10.0 * np.log10(intensity.astype(np.float32))
 
+        intensity_db = _round_float(intensity_db, INTENSITY_DB_QUANT)
         # compute fuzzy value
         (fuzzy_avgvalue, intensity_z, hand_z,
          slope_z, area_s, ref_water, copol_only) = \
             compute_fuzzy_value(
-                intensity=10*np.log10(intensity),
+                intensity=intensity_db,
                 slope=slope,
                 hand=interphand,
                 landcover=landcover_map,
@@ -421,9 +513,18 @@ def run(cfg):
                 workflow=workflow,
                 block_param=block_param)
 
-        fuzzy_avgvalue[interphand > option_dict['hand_threshold']] = 0
+        fuzzy_avgvalue[no_data_raster == 1] = -1
+        fuzzy_avgvalue[
+            _gt_eps(interphand, option_dict['hand_threshold'], eps=1.0e-6)
+        ] = 0
         fuzzy_avgvalue[no_data_raster == 1] = -1
 
+        valid_fuzzy = fuzzy_avgvalue != -1
+        fuzzy_avgvalue[valid_fuzzy] = _round_float(
+            fuzzy_avgvalue[valid_fuzzy],
+            FUZZY_VALUE_QUANT,
+        )
+        fuzzy_avgvalue = fuzzy_avgvalue.astype(np.float32)
         _dswx_sar_util.write_raster_block(
             out_raster=fuzzy_output_str,
             data=fuzzy_avgvalue,

--- a/src/dswx_sar/nisar/initial_threshold.py
+++ b/src/dswx_sar/nisar/initial_threshold.py
@@ -13,6 +13,7 @@ from scipy.optimize import curve_fit
 from scipy.signal import find_peaks
 from scipy.stats import norm
 from skimage.filters import threshold_multiotsu, threshold_otsu
+from scipy.ndimage import gaussian_filter1d
 
 from dswx_sar.common import (
     _dswx_sar_util,
@@ -28,6 +29,352 @@ from dswx_sar.nisar.dswx_ni_runconfig import (
 
 
 logger = logging.getLogger('dswx_sar')
+
+import json
+from pathlib import Path
+
+
+def _safe_float(x):
+    try:
+        x = float(x)
+        if np.isfinite(x):
+            return x
+        return None
+    except Exception:
+        return None
+
+
+def _array_summary(a):
+    a = np.asarray(a)
+    finite = np.isfinite(a)
+
+    out = {
+        "shape": list(a.shape),
+        "dtype": str(a.dtype),
+        "size": int(a.size),
+        "n_finite": int(finite.sum()),
+        "n_nan": int(np.isnan(a).sum()) if np.issubdtype(a.dtype, np.number) else None,
+        "n_inf": int(np.isinf(a).sum()) if np.issubdtype(a.dtype, np.number) else None,
+    }
+
+    if finite.any():
+        af = a[finite].astype(np.float64)
+        out.update({
+            "min": _safe_float(np.min(af)),
+            "max": _safe_float(np.max(af)),
+            "mean": _safe_float(np.mean(af)),
+            "std": _safe_float(np.std(af)),
+            "p01": _safe_float(np.percentile(af, 1)),
+            "p50": _safe_float(np.percentile(af, 50)),
+            "p99": _safe_float(np.percentile(af, 99)),
+        })
+    else:
+        out.update({
+            "min": None,
+            "max": None,
+            "mean": None,
+            "std": None,
+            "p01": None,
+            "p50": None,
+            "p99": None,
+        })
+
+    return out
+
+import hashlib
+
+
+def _array_hash(a, round_decimals=3, sort_values=True):
+    """
+    Create a stable hash for numerical arrays.
+
+    This is for debugging Intel/Mac reproducibility.
+    Rounding removes tiny numerical noise, and sorting makes the hash
+    insensitive to ordering if we only care about value distribution.
+    """
+    a = np.asarray(a)
+    a = a[np.isfinite(a)]
+
+    if a.size == 0:
+        return None
+
+    a = a.astype(np.float64)
+
+    if round_decimals is not None:
+        a = np.round(a, round_decimals)
+
+    if sort_values:
+        a = np.sort(a)
+
+    a = a.astype(np.float32)
+    return hashlib.sha256(a.tobytes()).hexdigest()
+
+def _pick_stable_peak_index(
+        counts,
+        candidate_indices=None,
+        prefer="first",
+        rel_tol=0.002,
+        abs_tol=1e-4):
+    """
+    Pick a histogram peak deterministically using a tolerance band.
+
+    Instead of selecting the exact maximum, this selects all peaks whose
+    heights are close to the maximum, then applies a fixed tie-break rule.
+    This avoids Intel/Mac flips when several histogram peaks are nearly equal.
+    """
+    counts = np.asarray(counts, dtype=np.float64)
+    counts = np.nan_to_num(counts, nan=0.0, posinf=0.0, neginf=0.0)
+
+    if counts.size == 0:
+        return 0
+
+    if candidate_indices is None or len(candidate_indices) == 0:
+        candidate_indices = np.arange(counts.size, dtype=int)
+    else:
+        candidate_indices = np.asarray(candidate_indices, dtype=int)
+
+    candidate_indices = candidate_indices[
+        (candidate_indices >= 0) & (candidate_indices < counts.size)
+    ]
+
+    if candidate_indices.size == 0:
+        candidate_indices = np.arange(counts.size, dtype=int)
+
+    vals = counts[candidate_indices]
+    max_val = np.max(vals)
+
+    tol = max(abs_tol, abs(max_val) * rel_tol)
+
+    # Include near-maximum peaks, not only the exact maximum.
+    tied = candidate_indices[vals >= max_val - tol]
+
+    if tied.size == 0:
+        return int(candidate_indices[np.argmax(vals)])
+
+    if prefer == "last":
+        return int(tied[-1])
+
+    if prefer == "center":
+        center = 0.5 * (counts.size - 1)
+        return int(tied[np.argmin(np.abs(tied - center))])
+
+    # default: stable low-index choice
+    return int(tied[0])
+
+
+def _pick_dominant_hist_mode(
+        bins,
+        counts,
+        candidate_slice=None,
+        rel_tol=0.002,
+        abs_tol=1e-4,
+        merge_gap=5,
+        smooth_sigma=1.0):
+    """
+    Pick a histogram mode deterministically.
+
+    Use a smoothed histogram only for selecting the dominant mode location.
+    The original counts are still returned for the selected bin amplitude.
+    """
+    bins = np.asarray(bins, dtype=np.float64)
+    counts = np.asarray(counts, dtype=np.float64)
+    counts = np.nan_to_num(counts, nan=0.0, posinf=0.0, neginf=0.0)
+
+    if candidate_slice is None:
+        offset = 0
+        sub_bins = bins
+        sub_counts = counts
+    else:
+        start = 0 if candidate_slice.start is None else candidate_slice.start
+        stop = len(counts) if candidate_slice.stop is None else candidate_slice.stop
+        offset = start
+        sub_bins = bins[start:stop]
+        sub_counts = counts[start:stop]
+
+    if sub_counts.size == 0 or np.all(sub_counts <= 0):
+        idx = min(max(offset, 0), len(bins) - 1)
+        return idx, float(bins[idx]), float(counts[idx]), {
+            "near_indices": [],
+            "groups": [],
+            "selected_group": None,
+            "centroid": None,
+            "smooth_sigma": smooth_sigma,
+        }
+
+    if smooth_sigma is not None and smooth_sigma > 0:
+        score_counts = gaussian_filter1d(sub_counts, sigma=smooth_sigma)
+    else:
+        score_counts = sub_counts.copy()
+
+    max_val = float(np.max(score_counts))
+    tol = max(abs_tol, abs(max_val) * rel_tol)
+    near_rel = np.where(score_counts >= max_val - tol)[0]
+
+    if near_rel.size == 0:
+        rel_idx = int(np.argmax(score_counts))
+        idx = offset + rel_idx
+        return idx, float(bins[idx]), float(counts[idx]), {
+            "near_indices": [],
+            "groups": [],
+            "selected_group": None,
+            "centroid": float(bins[idx]),
+            "smooth_sigma": smooth_sigma,
+        }
+
+    groups = []
+    current = [int(near_rel[0])]
+
+    for ii in near_rel[1:]:
+        ii = int(ii)
+        if ii - current[-1] <= merge_gap:
+            current.append(ii)
+        else:
+            groups.append(current)
+            current = [ii]
+    groups.append(current)
+
+    group_scores = []
+    for g in groups:
+        lo = max(0, min(g) - 1)
+        hi = min(sub_counts.size, max(g) + 2)
+
+        # Use smoothed counts for mass/centroid stability.
+        w = score_counts[lo:hi]
+        x = sub_bins[lo:hi]
+        mass = float(np.sum(w))
+
+        if mass > 0:
+            centroid = float(np.sum(x * w) / mass)
+        else:
+            centroid = float(sub_bins[g[0]])
+
+        group_scores.append((mass, centroid, lo, hi, g))
+
+    # Highest mass; deterministic tie by earlier centroid/bin
+    best = max(group_scores, key=lambda z: (z[0], -z[2]))
+    _, centroid, lo, hi, best_group = best
+
+    rel_idx = int(np.argmin(np.abs(sub_bins - centroid)))
+    idx = offset + rel_idx
+    idx = int(np.clip(idx, 0, len(bins) - 1))
+
+    debug = {
+        "near_indices": [int(offset + i) for i in near_rel],
+        "near_bins": [float(bins[offset + i]) for i in near_rel],
+        "groups": [[int(offset + j) for j in g] for g in groups],
+        "selected_group": [int(offset + j) for j in best_group],
+        "centroid": centroid,
+        "selected_index": int(idx),
+        "selected_bin": float(bins[idx]),
+        "selected_count": float(counts[idx]),
+        "smooth_sigma": smooth_sigma,
+    }
+
+    return idx, float(bins[idx]), float(counts[idx]), debug
+
+
+def _write_stage_record(out_dir, record):
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    path = out_dir / "stage_manifest.jsonl"
+    with open(path, "a") as f:
+        f.write(json.dumps(record, sort_keys=True) + "\n")
+
+import json
+from pathlib import Path
+
+
+def _json_safe(v):
+    """Convert numpy scalars/arrays to JSON-safe objects."""
+    if isinstance(v, np.ndarray):
+        return v.tolist()
+    if isinstance(v, (np.floating, np.integer)):
+        return v.item()
+    if isinstance(v, (list, tuple)):
+        return [_json_safe(x) for x in v]
+    if isinstance(v, dict):
+        return {k: _json_safe(val) for k, val in v.items()}
+    return v
+
+
+def save_curve_fit_case(
+        out_dir,
+        case_id,
+        *,
+        model_name,
+        pol=None,
+        block_ij=None,
+        coord=None,
+        absolute_coord=None,
+        intensity_sub=None,
+        intensity_bins=None,
+        intensity_counts=None,
+        expected=None,
+        bounds=None,
+        threshold_before_fit=None,
+        idx_threshold=None,
+        tau_mode_left=None,
+        tau_mode_right=None,
+        tau_amp_left=None,
+        tau_amp_right=None,
+        method=None,
+        threshold_scale=None):
+    """
+    Save one exact curve_fit test case.
+
+    Files:
+      curvefit_case_xxxxxx.npz  : numerical arrays
+      curvefit_case_xxxxxx.json : metadata
+    """
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    npz_path = out_dir / f"curvefit_case_{case_id:06d}_{model_name}.npz"
+    json_path = out_dir / f"curvefit_case_{case_id:06d}_{model_name}.json"
+
+    # Keep intensity_sub optional because it can be large.
+    arrays = {
+        "intensity_bins": np.asarray(intensity_bins, dtype=np.float64),
+        "intensity_counts": np.asarray(intensity_counts, dtype=np.float64),
+        "expected": np.asarray(expected, dtype=np.float64),
+        "lower_bounds": np.asarray(bounds[0], dtype=np.float64),
+        "upper_bounds": np.asarray(bounds[1], dtype=np.float64),
+    }
+
+    if intensity_sub is not None:
+        arrays["intensity_sub"] = np.asarray(intensity_sub, dtype=np.float32)
+
+    np.savez_compressed(npz_path, **arrays)
+
+    meta = {
+        "case_id": case_id,
+        "model_name": model_name,
+        "npz_path": str(npz_path),
+        "pol": pol,
+        "block_ij": block_ij,
+        "coord_local": coord,
+        "coord_absolute": absolute_coord,
+        "method": method,
+        "threshold_scale": threshold_scale,
+        "threshold_before_fit": threshold_before_fit,
+        "idx_threshold": idx_threshold,
+        "tau_mode_left": tau_mode_left,
+        "tau_mode_right": tau_mode_right,
+        "tau_amp_left": tau_amp_left,
+        "tau_amp_right": tau_amp_right,
+        "n_intensity_sub": None if intensity_sub is None else int(np.asarray(intensity_sub).size),
+        "n_bins": None if intensity_bins is None else int(np.asarray(intensity_bins).size),
+        "finite_counts": None if intensity_counts is None else int(np.isfinite(intensity_counts).sum()),
+        "counts_min": None if intensity_counts is None else float(np.nanmin(intensity_counts)),
+        "counts_max": None if intensity_counts is None else float(np.nanmax(intensity_counts)),
+    }
+
+    with open(json_path, "w") as f:
+        json.dump(_json_safe(meta), f, indent=2)
+
+    return str(npz_path), str(json_path)
+
 
 
 def convert_db2pow(db):
@@ -101,6 +448,79 @@ def _solve_gaussian_intersections_(m1, s1, A1, m2, s2, A2):
                    (-b + sqrt_disc) / (2.0 * a)])
 
 
+def _multiotsu_from_hist_deterministic(intensity_bins, intensity_counts):
+    """
+    Deterministic 3-class Otsu threshold from an existing histogram.
+
+    Returns two thresholds corresponding to skimage threshold_multiotsu(..., classes=3),
+    but uses canonical histogram bins/counts instead of rebuilding histogram
+    from samples.
+    """
+    x = np.asarray(intensity_bins, dtype=np.float64)
+    h = np.asarray(intensity_counts, dtype=np.float64)
+
+    h = np.nan_to_num(h, nan=0.0, posinf=0.0, neginf=0.0)
+    h = np.round(h, 12)
+
+    valid = np.isfinite(x) & np.isfinite(h) & (h >= 0)
+    x = x[valid]
+    h = h[valid]
+
+    if x.size < 3 or np.sum(h) <= 0:
+        return None
+
+    # Normalize, but keep deterministic float64 path.
+    p = h / np.sum(h)
+
+    P = np.cumsum(p)
+    S = np.cumsum(p * x)
+    S2 = np.cumsum(p * x * x)
+
+    total_mean = S[-1]
+
+    best_score = -np.inf
+    best_i = None
+    best_j = None
+
+    n = x.size
+
+    # classes: [0:i], [i+1:j], [j+1:end]
+    for i in range(0, n - 2):
+        w0 = P[i]
+        if w0 <= 0:
+            continue
+
+        m0 = S[i] / w0
+
+        for j in range(i + 1, n - 1):
+            w1 = P[j] - P[i]
+            w2 = 1.0 - P[j]
+
+            if w1 <= 0 or w2 <= 0:
+                continue
+
+            m1 = (S[j] - S[i]) / w1
+            m2 = (S[-1] - S[j]) / w2
+
+            score = (
+                w0 * (m0 - total_mean) ** 2
+                + w1 * (m1 - total_mean) ** 2
+                + w2 * (m2 - total_mean) ** 2
+            )
+
+            # Deterministic tie rule:
+            # if scores are extremely close, choose the lower thresholds.
+            if score > best_score + 1e-15:
+                best_score = score
+                best_i = i
+                best_j = j
+
+    if best_i is None or best_j is None:
+        return None
+
+    return np.array([x[best_i], x[best_j]], dtype=np.float64)
+
+
 def _tile_relaxed_threshold_from_boundary(
         intensity_tile_db,  # 2D (dB)
         tau_strict,         # scalar (dB)
@@ -170,6 +590,73 @@ def _tile_relaxed_threshold_from_boundary(
     return float(tau_new)
 
 
+def _otsu_threshold_from_hist(intensity_bins, intensity_counts):
+    x = np.asarray(intensity_bins, dtype=np.float64)
+    w = np.asarray(intensity_counts, dtype=np.float64)
+    w = np.nan_to_num(w, nan=0.0, posinf=0.0, neginf=0.0)
+
+    valid = np.isfinite(x) & np.isfinite(w) & (w > 0)
+    x = x[valid]
+    w = w[valid]
+
+    if x.size < 2 or np.sum(w) <= 0:
+        return np.nan
+
+    cw = np.cumsum(w)
+    cx = np.cumsum(w * x)
+
+    total_w = cw[-1]
+    total_x = cx[-1]
+
+    w0 = cw
+    w1 = total_w - cw
+
+    valid_split = (w0 > 0) & (w1 > 0)
+    if not np.any(valid_split):
+        return np.nan
+
+    mu0 = np.zeros_like(x)
+    mu1 = np.zeros_like(x)
+
+    mu0[valid_split] = cx[valid_split] / w0[valid_split]
+    mu1[valid_split] = (total_x - cx[valid_split]) / w1[valid_split]
+
+    between_var = np.full_like(x, -np.inf)
+    between_var[valid_split] = (
+        w0[valid_split]
+        * w1[valid_split]
+        * (mu0[valid_split] - mu1[valid_split]) ** 2
+    )
+
+    idx = int(np.argmax(between_var))
+    return float(x[idx])
+
+
+def _valid_bimodal_fit_for_threshold(first_mode, second_mode):
+    try:
+        f = np.asarray(first_mode, dtype=np.float64).ravel()
+        s = np.asarray(second_mode, dtype=np.float64).ravel()
+
+        if f.size < 3 or s.size < 3:
+            return False
+
+        m1, sig1, amp1 = f[:3]
+        m2, sig2, amp2 = s[:3]
+
+        sep = abs(m2 - m1)
+
+        return (
+            np.all(np.isfinite([m1, sig1, amp1, m2, sig2, amp2]))
+            and 0.05 <= sig1 <= 3.5
+            and 0.05 <= sig2 <= 3.5
+            and 0.01 <= amp1 <= 0.50
+            and 0.01 <= amp2 <= 0.50
+            and 0.5 <= sep <= 8.0
+        )
+    except Exception:
+        return False
+
+
 def determine_threshold(
         intensity,
         candidate_tile_coords,
@@ -182,6 +669,12 @@ def determine_threshold(
         adjust_if_nonoverlap=True,
         adjust_thresh_low_dist_percent=None,
         adjust_thresh_high_dist_percent=None,
+        extract_curvefit=False,
+        curvefit_out_dir=None,
+        pol=None,
+        block_ij=None,
+        block_origin=None,
+        threshold_scale=None,
         ):
     """Compute the thresholds and peak values for left Gaussian
     from intensity image for given candidate coordinates.
@@ -263,21 +756,92 @@ def determine_threshold(
     mode_array = []
     negligible_value = _dswx_sar_util.Constants.negligible_value
     min_threshold, max_threshold = bounds[0], bounds[1]
-
+    curvefit_case_id = 0
     for coord in candidate_tile_coords:
 
         # assume that coord consists of 5 elements
         ystart, yend, xstart, xend = coord[1:]
 
+        # Debug trace for threshold changes after stage_3
+        threshold_initial = None
+        threshold_after_ki_or_otsu = None
+        threshold_after_multiotsu = None
+        threshold_after_bimodal_fit = None
+        threshold_after_model_intersection = None
+        threshold_after_trimodal_fit = None
+        threshold_after_trimodal_override = None
+        threshold_after_rg = None
+        threshold_after_nonoverlap = None
+        threshold_after_tile_relax = None
+        threshold_after_margin_guard = None
+
+        mode_after_bimodal_fit = None
+        mode_after_model_intersection = None
+        mode_after_trimodal_fit = None
+        mode_after_margin_guard = None
+
+        bimodal_params_debug = None
+        trimodal_params_debug = None
+        first_mode_debug = None
+        second_mode_debug = None
+        tri_first_mode_debug = None
+        tri_second_mode_debug = None
+        tri_third_mode_debug = None
+
+        model_intersection_used = False
+        trimodal_override_used = False
+        tile_relax_used = False
+        margin_guard_used = False
+        hist_trimodal_override_used = False
+        threshold_before_margin_guard = None
         intensity_sub = intensity[ystart:yend,
                                   xstart:xend]
-
+        intensity_sub = np.asarray(intensity_sub, dtype=np.float64)
         # generate histogram with intensity higher than -35 dB
-        intensity_sub = intensity_sub[intensity_sub > -35]
+        if threshold_scale == "db":
+            intensity_sub = intensity_sub[intensity_sub > -35]
+        else:
+            intensity_sub = intensity_sub[intensity_sub > 0]
         intensity_sub = _initial_threshold.remove_invalid(intensity_sub)
+        intensity_sub = np.asarray(intensity_sub, dtype=np.float64)
+        intensity_sub = intensity_sub[np.isfinite(intensity_sub)]
 
+        if threshold_scale == "db":
+            # All threshold fitting in dB uses 0.001 dB precision.
+            intensity_sub = np.round(intensity_sub, 3).astype(np.float64)
+        else:
+            # Linear case keeps more precision.
+            intensity_sub = np.round(intensity_sub, 8).astype(np.float64)
+
+        if extract_curvefit and curvefit_out_dir is not None:
+
+            _write_stage_record(curvefit_out_dir, {
+                "stage": "stage_2_tile_prepare",
+                "model_context": "before_histogram",
+                "pol": pol,
+                "block_ij": list(block_ij) if block_ij is not None else None,
+                "coord_local": [int(ystart), int(yend), int(xstart), int(xend)],
+                "coord_absolute": [
+                    int(block_origin[0] + ystart),
+                    int(block_origin[0] + yend),
+                    int(block_origin[1] + xstart),
+                    int(block_origin[1] + xend),
+                ] if block_origin is not None else None,
+                "n_after_filter": int(intensity_sub.size),
+                "intensity_sub": _array_summary(intensity_sub),
+                "intensity_sub_hash_round3": _array_hash(intensity_sub, 3),
+                "intensity_sub_hash_round4": _array_hash(intensity_sub, 4),
+                "min_intensity_histogram": _safe_float(min_intensity_histogram),
+                "max_intensity_histogram": _safe_float(max_intensity_histogram),
+                "step_histogram": _safe_float(step_histogram),
+                "method": method,
+                "threshold_scale": threshold_scale,
+            })
         if intensity_sub.size == 0:
-            return np.nan, np.nan
+            threshold_array.append(np.nan)
+            threshold_idx_array.append(-1)
+            mode_array.append(np.nan)
+            continue
 
         if (not np.isfinite(min_intensity_histogram)) or (not np.isfinite(max_intensity_histogram)) \
         or (max_intensity_histogram <= min_intensity_histogram):
@@ -296,7 +860,8 @@ def determine_threshold(
                         max(2, numstep + 1))
 
         intensity_counts, bins = np.histogram(intensity_sub, bins=bins, density=True)
-
+        intensity_counts = np.asarray(intensity_counts, dtype=np.float64)
+        intensity_bins = np.asarray(bins[:-1], dtype=np.float64)
         # If density=True produced NaNs (zero bin width / empty), retry with density=False
         if not np.isfinite(intensity_counts).any():
             intensity_counts, bins = np.histogram(intensity_sub, bins=bins, density=False)
@@ -305,16 +870,22 @@ def determine_threshold(
         intensity_counts = np.nan_to_num(intensity_counts, nan=0.0, posinf=0.0, neginf=0.0)
         intensity_bins = bins[:-1]
 
+        intensity_bins = np.asarray(intensity_bins, dtype=np.float64)
+        intensity_counts = np.asarray(intensity_counts, dtype=np.float64)
+
+        # Canonicalize histogram for reproducible peak search and curve_fit.
+        intensity_bins = np.round(intensity_bins, 6).astype(np.float64)
+        intensity_counts = np.round(intensity_counts, 12).astype(np.float64)
         if method == 'ki':
-            threshold, idx_threshold = _initial_threshold.compute_ki_threshold(
-                intensity_sub,
-                min_intensity_histogram,
-                max_intensity_histogram,
-                step_histogram)
+            threshold, idx_threshold, ki_prob_array = _initial_threshold.compute_ki_threshold_from_hist(
+                intensity_bins,
+                intensity_counts
+            )
 
         elif method in ['otsu', 'rg']:
             threshold = threshold_otsu(intensity_sub)
-
+        threshold_after_ki_or_otsu = _safe_float(threshold)
+        threshold_initial = _safe_float(threshold)
         # get index of threshold from histogram.
         idx_threshold = np.searchsorted(intensity_bins, threshold)
         idx_threshold = int(np.clip(idx_threshold, 0, max(0, len(intensity_bins) - 1)))
@@ -322,44 +893,74 @@ def determine_threshold(
         # if estimated threshold is higher than bounds,
         # re-estimate threshold assuming tri-mode distribution
         if threshold > bounds[1] and multi_threshold:
-            try:
-                thresholds = threshold_multiotsu(intensity_sub)
+            thresholds = _multiotsu_from_hist_deterministic(
+                intensity_bins,
+                intensity_counts,
+            )
 
-                if thresholds[0] < threshold:
-                    threshold = thresholds[0]
-                    idx_threshold = np.searchsorted(intensity_bins, threshold)
-            except ValueError:
-                logger.info('Unable to find multi threshold')
+            if thresholds is not None and thresholds[0] < threshold:
+                threshold = float(thresholds[0])
+                idx_threshold = np.searchsorted(intensity_bins, threshold)
 
+        threshold_after_multiotsu = _safe_float(threshold)
         # Make sure idx_threshold is within bounds
         idx_threshold = int(np.clip(idx_threshold, 0, max(0, len(intensity_bins) - 1)))
+        lowmaxind, tau_mode_left, tau_amp_left, low_peak_debug = \
+            _pick_dominant_hist_mode(
+                intensity_bins,
+                intensity_counts,
+                candidate_slice=slice(0, idx_threshold + 1),
+                rel_tol=0.002,
+                abs_tol=1e-4,
+                merge_gap=5,
+                smooth_sigma=1.0,
+            )
 
-        # Low-side slice (<= threshold)
-        low_slice = intensity_counts[:idx_threshold + 1]
-        low_slice = np.nan_to_num(low_slice, nan=0.0)
+        highmaxind, tau_mode_right, tau_amp_right, high_peak_debug = \
+            _pick_dominant_hist_mode(
+                intensity_bins,
+                intensity_counts,
+                candidate_slice=slice(idx_threshold, len(intensity_counts)),
+                rel_tol=0.002,
+                abs_tol=1e-4,
+                merge_gap=5,
+                smooth_sigma=1.0,
+            )
+        # # Low-side slice (<= threshold)
+        # low_slice = intensity_counts[:idx_threshold + 1]
+        # low_slice = np.nan_to_num(low_slice, nan=0.0, posinf=0.0, neginf=0.0)
 
-        if low_slice.size == 0 or not np.isfinite(low_slice).any() or np.all(low_slice == 0):
-            lowmaxind = max(0, idx_threshold)   # safe fallback
-        else:
-            lowmaxind_cands, _ = find_peaks(low_slice, distance=5)
-            if lowmaxind_cands.size == 0:
-                lowmaxind = int(np.argmax(low_slice))
-            else:
-                lowmaxind = int(lowmaxind_cands[np.argmax(low_slice[lowmaxind_cands])])
+        # if low_slice.size == 0 or not np.isfinite(low_slice).any() or np.all(low_slice == 0):
+        #     lowmaxind = max(0, idx_threshold)
+        #     lowmaxind_cands = np.array([], dtype=int)
+        # else:
+        #     lowmaxind_cands, _ = find_peaks(low_slice, distance=5)
 
-        # High-side slice (>= threshold)
-        high_slice = intensity_counts[idx_threshold:]
-        high_slice = np.nan_to_num(high_slice, nan=0.0)
+        #     lowmaxind = _pick_stable_peak_index(
+        #         low_slice,
+        #         lowmaxind_cands,
+        #         prefer="first",
+        #         rel_tol=0.002,
+        #         abs_tol=1e-4,
+        #     )
+        # # High-side slice (>= threshold)
+        # high_slice = intensity_counts[idx_threshold:]
+        # high_slice = np.nan_to_num(high_slice, nan=0.0, posinf=0.0, neginf=0.0)
 
-        if high_slice.size == 0 or not np.isfinite(high_slice).any() or np.all(high_slice == 0):
-            highmaxind = idx_threshold
-        else:
-            highmaxind_cands, _ = find_peaks(high_slice, distance=5)
-            if highmaxind_cands.size == 0:
-                highmaxind_rel = int(np.argmax(high_slice))
-            else:
-                highmaxind_rel = int(highmaxind_cands[np.argmax(high_slice[highmaxind_cands])])
-            highmaxind = idx_threshold + highmaxind_rel
+        # if high_slice.size == 0 or not np.isfinite(high_slice).any() or np.all(high_slice == 0):
+        #     highmaxind = idx_threshold
+        #     highmaxind_cands = np.array([], dtype=int)
+        # else:
+        #     highmaxind_cands, _ = find_peaks(high_slice, distance=5)
+
+        #     highmaxind_rel = _pick_stable_peak_index(
+        #         high_slice,
+        #         highmaxind_cands,
+        #         prefer="first",
+        #         rel_tol=0.002,
+        #         abs_tol=1e-4,
+        #     )
+        #     highmaxind = idx_threshold + highmaxind_rel
 
         # Clamp indices
         lowmaxind  = int(np.clip(lowmaxind,  0, len(intensity_bins) - 1))
@@ -375,20 +976,99 @@ def determine_threshold(
 
         tau_amp_left = intensity_counts[lowmaxind]
         tau_amp_right = intensity_counts[highmaxind]
-
+        modevalue = float(tau_mode_left)
+        optimization = False
+        tri_optimization = False
+        lock_mode_from_model = False
         try:
-            expected = (tau_mode_left, .5, tau_amp_left,
-                        tau_mode_right, .5, tau_amp_right)
 
-            params, _ = curve_fit(
-                _initial_threshold.bimodal,
-                intensity_bins,
-                intensity_counts,
-                expected,
-                bounds=((-30, 0.001, 0.01,
+            expected = np.array(
+                [tau_mode_left, .5, tau_amp_left,
+                tau_mode_right, .5, tau_amp_right],
+                dtype=np.float64
+            )
+            expected = np.round(expected, 12)
+
+            fit_bounds = ((-30, 0.001, 0.01,
                         -30, 0.001, 0.01),
                         (5, 5, 0.95,
-                        5, 5, 0.95)))
+                        5, 5, 0.95))
+
+            if extract_curvefit and curvefit_out_dir is not None:
+                if block_origin is not None:
+                    abs_coord = [
+                        int(block_origin[0] + ystart),
+                        int(block_origin[0] + yend),
+                        int(block_origin[1] + xstart),
+                        int(block_origin[1] + xend),
+                    ]
+                else:
+                    abs_coord = None
+                _write_stage_record(curvefit_out_dir, {
+                    "stage": "stage_3_fit_ready",
+                    "model_name": "bimodal",
+                    "pol": pol,
+                    "block_ij": list(block_ij) if block_ij is not None else None,
+                    "coord_local": [int(ystart), int(yend), int(xstart), int(xend)],
+                    "coord_absolute": [
+                        int(block_origin[0] + ystart),
+                        int(block_origin[0] + yend),
+                        int(block_origin[1] + xstart),
+                        int(block_origin[1] + xend),
+                    ] if block_origin is not None else None,
+                    "threshold_before_fit": _safe_float(threshold),
+                    "idx_threshold": int(idx_threshold),
+                    "tau_mode_left": _safe_float(tau_mode_left),
+                    "tau_mode_right": _safe_float(tau_mode_right),
+                    "tau_amp_left": _safe_float(tau_amp_left),
+                    "tau_amp_right": _safe_float(tau_amp_right),
+                    "intensity_bins": _array_summary(intensity_bins),
+                    "intensity_bins_hash_round6": _array_hash(intensity_bins, 6),
+                    "intensity_counts_hash_round12": _array_hash(intensity_counts, 12),
+                    "intensity_counts": _array_summary(intensity_counts),
+                    "expected": [float(x) for x in expected],
+                    "lowmaxind": int(lowmaxind),
+                    "highmaxind": int(highmaxind),
+                    "low_peak_debug": low_peak_debug,
+                    "high_peak_debug": high_peak_debug,
+                    "ki_threshold_from_hist": _safe_float(threshold),
+                    "ki_idx_from_hist": int(idx_threshold),
+
+                })
+                save_curve_fit_case(
+                    curvefit_out_dir,
+                    curvefit_case_id,
+                    model_name="bimodal",
+                    pol=pol,
+                    block_ij=block_ij,
+                    coord=[int(ystart), int(yend), int(xstart), int(xend)],
+                    absolute_coord=abs_coord,
+                    intensity_sub=intensity_sub,
+                    intensity_bins=intensity_bins,
+                    intensity_counts=intensity_counts,
+                    expected=expected,
+                    bounds=fit_bounds,
+                    threshold_before_fit=float(threshold),
+                    idx_threshold=int(idx_threshold),
+                    tau_mode_left=float(tau_mode_left),
+                    tau_mode_right=float(tau_mode_right),
+                    tau_amp_left=float(tau_amp_left),
+                    tau_amp_right=float(tau_amp_right),
+                    method=method,
+                    threshold_scale=threshold_scale,
+                )
+                curvefit_case_id += 1
+            x_fit = np.asarray(intensity_bins, dtype=np.float64)
+            y_fit = np.asarray(intensity_counts, dtype=np.float64)
+            p0_fit = np.asarray(expected, dtype=np.float64)
+            params, _ = curve_fit(
+                _initial_threshold.bimodal,
+                x_fit,
+                y_fit,
+                p0=p0_fit,
+                bounds=fit_bounds
+            )
+
             if params[0] > params[3]:
                 second_mode = params[:3]
                 first_mode = params[3:]
@@ -396,19 +1076,55 @@ def determine_threshold(
                 first_mode = params[:3]
                 second_mode = params[3:]
 
-            if USE_MODEL_INTERSECTION:
+            bimodal_params_debug = [float(x) for x in np.asarray(params).ravel()]
+            first_mode_debug = [float(x) for x in np.asarray(first_mode).ravel()]
+            second_mode_debug = [float(x) for x in np.asarray(second_mode).ravel()]
+
+            bimodal_fit_valid = _valid_bimodal_fit_for_threshold(
+                first_mode,
+                second_mode,
+            )
+            threshold_after_bimodal_fit = _safe_float(threshold)
+            mode_after_bimodal_fit = _safe_float(tau_mode_left)
+            min_sigma_for_model_intersection = 0.05
+
+            use_model_intersection_this_tile = (
+                USE_MODEL_INTERSECTION
+                and bimodal_fit_valid
+            )
+
+            if use_model_intersection_this_tile:
                 try:
                     threshold_model, mode_lower = _threshold_from_bimodal_fit(
                         first_mode, second_mode, bounds=bounds, p_low=0.98, p_high=0.02
                     )
-                    threshold = threshold_model
-                    modevalue = mode_lower
+
+                    model_intersection_used = True
+
+                    MODEL_INTERSECTION_MAX_SHIFT_DB = 0.25
+                    model_shift = abs(threshold_model - threshold)
+
+                    if model_shift <= MODEL_INTERSECTION_MAX_SHIFT_DB:
+                        threshold = threshold_model
+                        modevalue = mode_lower
+                        model_intersection_used = True
+                    else:
+                        model_intersection_used = False
+                        threshold = threshold
+                        modevalue = float(tau_mode_left)
                     idx_threshold = np.searchsorted(intensity_bins, threshold)
                     idx_threshold = int(np.clip(idx_threshold, 0, max(0, len(intensity_bins) - 1)))
+                    threshold_after_model_intersection = _safe_float(threshold)
+                    mode_after_model_intersection = _safe_float(modevalue)
                 except Exception as e:
+                    modevalue = float(tau_mode_left)
+                    threshold_after_model_intersection = _safe_float(threshold)
+                    mode_after_model_intersection = _safe_float(modevalue)
                     logger.info(f'Model-intersection override skipped (error: {e}); keeping KI/Otsu.')
-
-            lock_mode_from_model = USE_MODEL_INTERSECTION
+            else:
+                threshold_after_model_intersection = _safe_float(threshold)
+                mode_after_model_intersection = _safe_float(modevalue if 'modevalue' in locals() else tau_mode_left)
+            lock_mode_from_model = model_intersection_used
 
             simul_first = _initial_threshold.gauss(intensity_bins, *first_mode)
             simul_second = _initial_threshold.gauss(intensity_bins, *second_mode)
@@ -432,31 +1148,81 @@ def determine_threshold(
 
             optimization = True
 
-        except:
+        except Exception as e:
             optimization = False
             logger.info(
-                'Bimodal curve Fitting fails in threshold computation.')
+                f'Bimodal curve Fitting fails in threshold computation: {e}')
             modevalue = tau_mode_left
+
+            threshold_after_bimodal_fit = _safe_float(threshold)
+            mode_after_bimodal_fit = _safe_float(modevalue)
+            threshold_after_model_intersection = _safe_float(threshold)
+            mode_after_model_intersection = _safe_float(modevalue)
         try:
             dividers = threshold_multiotsu(intensity_sub)
 
             expected = (dividers[0], .5, tau_amp_left,
                         dividers[1], .5, tau_amp_right,
                         (dividers[0]+dividers[1])/2, .5, 0.1)
-            # curve_fit fits the trimodal distributions
-            # All distributions are assumed to be in the bound
-            # -35 to 5 dB, with standard deviation of 0 - 10[dB]
-            # and amplitudes of 0.01 to 0.95.
-            params, _ = curve_fit(_initial_threshold.trimodal,
-                                  intensity_bins,
-                                  intensity_counts,
-                                  expected,
-                                  bounds=((-35, 0.001, 0.01,
-                                           -35, 0.001, 0.01,
-                                           -35, 0.001, 0.01),
-                                          (5, 10, 0.95,
-                                           5, 10, 0.95,
-                                           5, 10, 0.95)))
+            expected = np.array(
+                [dividers[0], .5, tau_amp_left,
+                dividers[1], .5, tau_amp_right,
+                (dividers[0] + dividers[1]) / 2, .5, 0.1],
+                dtype=np.float64
+            )
+            expected = np.round(expected, 12)
+            fit_bounds = ((-35, 0.001, 0.01,
+                        -35, 0.001, 0.01,
+                        -35, 0.001, 0.01),
+                        (5, 10, 0.95,
+                        5, 10, 0.95,
+                        5, 10, 0.95))
+
+            if extract_curvefit and curvefit_out_dir is not None:
+                if block_origin is not None:
+                    abs_coord = [
+                        int(block_origin[0] + ystart),
+                        int(block_origin[0] + yend),
+                        int(block_origin[1] + xstart),
+                        int(block_origin[1] + xend),
+                    ]
+                else:
+                    abs_coord = None
+
+                save_curve_fit_case(
+                    curvefit_out_dir,
+                    curvefit_case_id,
+                    model_name="trimodal",
+                    pol=pol,
+                    block_ij=block_ij,
+                    coord=[int(ystart), int(yend), int(xstart), int(xend)],
+                    absolute_coord=abs_coord,
+                    intensity_sub=intensity_sub,
+                    intensity_bins=intensity_bins,
+                    intensity_counts=intensity_counts,
+                    expected=expected,
+                    bounds=fit_bounds,
+                    threshold_before_fit=float(threshold),
+                    idx_threshold=int(idx_threshold),
+                    tau_mode_left=float(tau_mode_left),
+                    tau_mode_right=float(tau_mode_right),
+                    tau_amp_left=float(tau_amp_left),
+                    tau_amp_right=float(tau_amp_right),
+                    method=method,
+                    threshold_scale=threshold_scale,
+                )
+                curvefit_case_id += 1
+
+            x_fit = np.asarray(intensity_bins, dtype=np.float64)
+            y_fit = np.asarray(intensity_counts, dtype=np.float64)
+            p0_fit = np.asarray(expected, dtype=np.float64)
+            params, _ = curve_fit(
+                _initial_threshold.trimodal,
+                    x_fit,
+                    y_fit,
+                    p0=p0_fit,
+                    bounds=fit_bounds
+                )
 
             # re-sort the order of estimated modes using amplitudes
             first_setind = 0
@@ -473,21 +1239,34 @@ def determine_threshold(
             tri_first_mode = params[first_setind:first_setind+3]
             tri_second_mode = params[second_setind:second_setind+3]
             tri_third_mode = params[third_setind:third_setind+3]
+            tri_modes = [tri_first_mode, tri_second_mode, tri_third_mode]
 
-            simul_second_sum = np.sum(simul_second)
-            if simul_second_sum == 0:
-                simul_second_sum = negligible_value
-            converge_ind = np.where((intensity_bins < tau_mode_right)
-                                    & (intensity_bins > tau_mode_left)
-                                    & (intensity_bins < threshold)
-                                    & (np.cumsum(simul_second) /
-                                       simul_second_sum < 0.03))
+            tri_sigmas = np.array([m[1] for m in tri_modes], dtype=np.float64)
+            tri_amps = np.array([m[2] for m in tri_modes], dtype=np.float64)
+            tri_means = np.array([m[0] for m in tri_modes], dtype=np.float64)
 
-            if len(converge_ind[0]):
-                modevalue = intensity_bins[converge_ind[0][-1]]
+            trimodal_params_debug = [float(x) for x in np.asarray(params).ravel()]
+            tri_first_mode_debug = [float(x) for x in np.asarray(tri_first_mode).ravel()]
+            tri_second_mode_debug = [float(x) for x in np.asarray(tri_second_mode).ravel()]
+            tri_third_mode_debug = [float(x) for x in np.asarray(tri_third_mode).ravel()]
 
-            else:
-                modevalue = tau_mode_left
+            threshold_after_trimodal_fit = _safe_float(threshold)
+            mode_after_trimodal_fit = _safe_float(modevalue)
+
+            # simul_second_sum = np.sum(simul_second)
+            # if simul_second_sum == 0:
+            #     simul_second_sum = negligible_value
+            # converge_ind = np.where((intensity_bins < tau_mode_right)
+            #                         & (intensity_bins > tau_mode_left)
+            #                         & (intensity_bins < threshold)
+            #                         & (np.cumsum(simul_second) /
+            #                            simul_second_sum < 0.03))
+
+            # if len(converge_ind[0]):
+            #     modevalue = intensity_bins[converge_ind[0][-1]]
+
+            # else:
+            #     modevalue = tau_mode_left
 
             large_amp = np.max([tri_first_mode[2],
                                 tri_second_mode[2],
@@ -509,50 +1288,149 @@ def determine_threshold(
 
             else:
                 third_second_dist_bool = False
+            tri_means = np.array([
+                tri_first_mode[0],
+                tri_second_mode[0],
+                tri_third_mode[0],
+            ], dtype=np.float64)
 
+            tri_sigmas = np.array([
+                tri_first_mode[1],
+                tri_second_mode[1],
+                tri_third_mode[1],
+            ], dtype=np.float64)
+
+            tri_amps = np.array([
+                tri_first_mode[2],
+                tri_second_mode[2],
+                tri_third_mode[2],
+            ], dtype=np.float64)
+
+            tri_fit_valid = (
+                np.all(np.isfinite(tri_means))
+                and np.all(np.isfinite(tri_sigmas))
+                and np.all(np.isfinite(tri_amps))
+                and np.all(tri_sigmas >= 0.05)
+                and np.all(tri_sigmas <= 3.5)
+                and np.all(tri_amps >= 0.01)
+                and np.all(tri_amps <= 0.50)
+                            )
+
+            tri_modes_separated = (
+                abs(tri_second_mode[0] - tri_first_mode[0]) >= 1.0
+                and abs(tri_third_mode[0] - tri_second_mode[0]) >= 1.0
+            )
+
+            tri_middle_reasonable = (
+                tri_second_mode[1] <= 3.0
+                and tri_second_mode[2] >= 0.02
+            )
+
+            degenerate_trimodal = not (
+                tri_fit_valid
+                and tri_modes_separated
+                and tri_middle_reasonable
+            )
             intensity_sub_min = np.nanmin(intensity_sub)
-            if tri_ratio_bool and third_second_dist_bool and \
-               first_second_dist_bool and tri_first_mode[0] > -32 and \
-               intensity_sub_min < tri_second_mode[0]:
+            if (
+                (not degenerate_trimodal)
+                and tri_ratio_bool
+                and third_second_dist_bool
+                and first_second_dist_bool
+                and tri_first_mode[0] > -32
+                and intensity_sub_min < tri_second_mode[0]
+            ):
                 tri_optimization = True
-            else:
-                tri_optimization = False
 
-        except:
+        except Exception as e:
+            logger.info(
+                "Trimodal curve fitting failed in threshold computation: %s",
+                e,
+            )
             tri_optimization = False
+            trimodal_params_debug = None
+            tri_first_mode_debug = None
+            tri_second_mode_debug = None
+            tri_third_mode_debug = None
             logger.info(
                 'Trimodal curve Fitting fails in threshold computation.')
+        threshold_after_trimodal_fit = _safe_float(threshold)
+        mode_after_trimodal_fit = _safe_float(modevalue)
 
-        if tri_optimization:
-            intensity_sub2 = intensity_sub[intensity_sub < tri_second_mode[0]]
+        ENABLE_HIST_TRIMODAL_OVERRIDE = True
 
-            if intensity_sub2.size > 0:
-                tau_bound_gauss = threshold_otsu(intensity_sub2)
+        hist_trimodal_override_used = False
+        threshold_before_hist_trimodal = float(threshold)
 
-                if threshold > tau_bound_gauss:
-                    threshold = tau_bound_gauss
-                    idx_tau_bound_gauss = np.searchsorted(intensity_bins,
-                                                          threshold)
-                    tri_lowmaxind_cands, _ = find_peaks(
-                        intensity_counts[0:idx_tau_bound_gauss+1],
-                        distance=5)
+        if ENABLE_HIST_TRIMODAL_OVERRIDE and multi_threshold:
+            try:
+                # Use deterministic histogram-based multi-Otsu.
+                dividers = _multiotsu_from_hist_deterministic(
+                    intensity_bins,
+                    intensity_counts,
+                )
 
-                    if not tri_lowmaxind_cands.any():
-                        tri_lowmaxind_cands = np.array(
-                            [np.nanargmax(
-                             intensity_counts[: idx_tau_bound_gauss+1])])
-                    intensity_counts_cand = intensity_counts[
-                        tri_lowmaxind_cands]
-                    tri_lowmaxind = tri_lowmaxind_cands[
-                        np.nanargmax(intensity_counts_cand)]
-                    tri_lowmaxind = np.squeeze(tri_lowmaxind)
+                if dividers is not None and len(dividers) >= 2:
+                    low_mid_divider = float(dividers[0])
+                    mid_high_divider = float(dividers[1])
 
-                    if tri_lowmaxind.size > 1:
-                        tri_lowmaxind = tri_lowmaxind[tri_lowmaxind <=
-                                                      idx_tau_bound_gauss]
-                        tri_lowmaxind = tri_lowmaxind[0]
-                    modevalue = intensity_bins[tri_lowmaxind]
+                    hist_mask = intensity_bins < mid_high_divider
 
+                    if (
+                        np.count_nonzero(hist_mask) > 2
+                        and np.sum(intensity_counts[hist_mask]) > 0
+                    ):
+                        tau_bound_hist = _otsu_threshold_from_hist(
+                            intensity_bins[hist_mask],
+                            intensity_counts[hist_mask],
+                        )
+
+                        TRI_Q = 0.01
+
+                        threshold_before_q = (
+                            np.round(threshold_before_hist_trimodal / TRI_Q) * TRI_Q
+                        )
+                        proposed_q = (
+                            np.round(tau_bound_hist / TRI_Q) * TRI_Q
+                        )
+
+                        shift_db = abs(proposed_q - threshold_before_q)
+
+                        # Conservative: do not accept one-bin / borderline corrections.
+                        min_trimodal_shift_db = 0.11
+                        max_trimodal_shift_db = 0.25
+
+                        accept_hist_trimodal = (
+                            np.isfinite(proposed_q)
+                            and threshold_before_q > proposed_q
+                            and min_trimodal_shift_db <= shift_db <= max_trimodal_shift_db
+                            and proposed_q >= bounds[0]
+                            and proposed_q <= bounds[1]
+                        )
+
+                        if accept_hist_trimodal:
+                            threshold = float(proposed_q)
+                            trimodal_override_used = True
+                            hist_trimodal_override_used = True
+                        else:
+                            threshold = float(threshold_before_q)
+                            trimodal_override_used = False
+                            hist_trimodal_override_used = False
+                    else:
+                        threshold = float(
+                            np.round(threshold_before_hist_trimodal / 0.01) * 0.01
+                        )
+                        trimodal_override_used = False
+                        hist_trimodal_override_used = False
+
+            except Exception as e:
+                threshold = float(
+                    np.round(threshold_before_hist_trimodal / 0.01) * 0.01
+                )
+                trimodal_override_used = False
+                hist_trimodal_override_used = False
+                logger.info(f'Histogram trimodal override skipped: {e}')
+        threshold_after_trimodal_override = _safe_float(threshold)
         if method == 'rg':
             intensity_countspp, _ = np.histogram(
                 intensity_sub,
@@ -570,11 +1448,8 @@ def determine_threshold(
                 diff_dist = intensity_counts - simul_first
                 diff_dist[idx_threshold:] = np.nan
 
-                if len(lowmaxind_cands) > 1:
-                    lowmaxind_cands = lowmaxind_cands[-1]
-                diff_dist[:int(lowmaxind_cands)] = np.nan
+                diff_dist[:int(lowmaxind)] = np.nan
                 diff_dist_ind = np.where(diff_dist > 0.05)
-
                 if len(diff_dist_ind[0]) > 0:
                     diverse_ind = diff_dist_ind[0][0]
                     modevalue = (modevalue + intensity_bins[diverse_ind]) / 2
@@ -615,15 +1490,19 @@ def determine_threshold(
                             rms_xx.append(hist_bin)
                         else:
                             rms_sss.append(np.nan)
-                            rms_sss.append(hist_bin)
+                            rms_xx.append(hist_bin)
+                valid = np.isfinite(rms_sss) & np.isfinite(rms_xx)
+                if np.any(valid):
+                    valid_indices = np.flatnonzero(valid)
+                    best_index = valid_indices[np.argmin(rms_sss[valid])]
+                    rg_tolerance = rms_xx[best_index]
+                    threshold = 0.5 * (rg_tolerance + threshold)
 
-                min_rms_ind = np.where(rms_sss)
-                rg_tolerance = rms_xx[min_rms_ind[0][0]]
-                threshold = (rg_tolerance + threshold) / 2
-
+        threshold_after_rg = _safe_float(threshold)
+        threshold_before_nonoverlap = None
         if adjust_if_nonoverlap:
             old_threshold = threshold
-
+            threshold_before_nonoverlap = None
             if optimization:
                 mean1, std1 = first_mode[0:2]
                 mean2, std2 = second_mode[0:2]
@@ -638,25 +1517,41 @@ def determine_threshold(
                     max_iterations=100,
                     thresh_low_dist_percent=adjust_thresh_low_dist_percent,
                     thresh_high_dist_percent=adjust_thresh_high_dist_percent)
-
+            threshold_before_nonoverlap = _safe_float(old_threshold)
+        threshold_after_nonoverlap = _safe_float(threshold)
         # --- TILE-WISE RELAXED THRESHOLD (data-driven; optional) ---
+        threshold_before_tile_relax = None
+        threshold_before_tile_relax = _safe_float(threshold)
+
         if TILE_RELAX:
             try:
-                # use the tile's intensities (already in dB)
+                threshold_before_relax = float(threshold)
+
                 tau_relaxed = _tile_relaxed_threshold_from_boundary(
                     intensity_tile_db=intensity_sub,
-                    tau_strict=float(threshold),
+                    tau_strict=threshold_before_relax,
                     max_band_px=3,
-                    core_iter=1)
-                threshold = float(tau_relaxed)
-            except Exception:
-                pass
+                    core_iter=1,
+                )
 
-        # add final threshold to threshold list
-        threshold_array.append(threshold)
-        threshold_idx_array.append(idx_threshold)
-        mode_array.append(modevalue)
+                if np.isfinite(tau_relaxed):
+                    tau_relaxed = float(tau_relaxed)
 
+                    max_tile_relax_shift_db = 0.5
+                    relax_shift_db = abs(tau_relaxed - threshold_before_relax)
+
+                    if relax_shift_db <= max_tile_relax_shift_db:
+                        if relax_shift_db > 1e-12:
+                            tile_relax_used = True
+                        threshold = tau_relaxed
+                    else:
+                        tile_relax_used = False
+                        threshold = threshold_before_relax
+
+            except Exception as e:
+                logger.info(f'Tile relaxed threshold skipped: {e}')
+
+        threshold_after_tile_relax = _safe_float(threshold)
 
         idx_threshold = np.searchsorted(intensity_bins, threshold)
         idx_threshold = int(np.clip(idx_threshold, 0, max(0, len(intensity_bins) - 1)))
@@ -664,36 +1559,127 @@ def determine_threshold(
         # Recompute the lower slice up to the final threshold
         low_slice_final = np.nan_to_num(intensity_counts[:idx_threshold + 1], nan=0.0)
 
-        if optimization:
-            # left Gaussian mean
-            if lock_mode_from_model:
-                # keep the lower-Gaussian mean from the model
-                modevalue_final = first_mode[0]
-            else:
-                # legacy behavior
-                modevalue_final = min(first_mode[0], intensity_bins[idx_threshold])
-            # modevalue_final = min(first_mode[0], intensity_bins[idx_threshold])
+        if low_slice_final.size == 0 or np.all(low_slice_final == 0):
+            hist_mode_final = intensity_bins[max(0, idx_threshold)]
         else:
-            # fallback: histogram peak on low side
-            if low_slice.size == 0 or np.all(low_slice == 0):
-                modevalue_final = intensity_bins[max(0, idx_threshold)]
-            else:
-                lowmaxind_cands_final, _ = find_peaks(low_slice_final, distance=5)
-                if lowmaxind_cands_final.size == 0:
-                    lowmaxind_final = int(np.argmax(low_slice_final))
-                else:
-                    lowmaxind_final = int(lowmaxind_cands_final[
-                        np.argmax(low_slice_final[lowmaxind_cands_final])])
-                lowmaxind_final = int(np.clip(lowmaxind_final, 0, idx_threshold))
-                modevalue_final = intensity_bins[lowmaxind_final]
+            lowmaxind_final, hist_mode_final, _, low_final_debug = \
+                _pick_dominant_hist_mode(
+                    intensity_bins,
+                    intensity_counts,
+                    candidate_slice=slice(0, idx_threshold + 1),
+                    rel_tol=0.002,
+                    abs_tol=1e-4,
+                    merge_gap=5,
+                    smooth_sigma=1.0,
+                )
+
+        # Critical reproducibility rule:
+        # Do not use first_mode[0] for final mode unless the fitted model was
+        # actually accepted to modify the threshold.
+        if model_intersection_used and optimization and bimodal_fit_valid:
+            modevalue_final = float(tau_mode_left)
+        else:
+            modevalue_final = float(hist_mode_final)
+        FINAL_QUANTIZE_DB = 0.01
+
+        if threshold_scale == "db":
+            if np.isfinite(threshold):
+                threshold = np.round(threshold / FINAL_QUANTIZE_DB) * FINAL_QUANTIZE_DB
+
+            if np.isfinite(modevalue_final):
+                modevalue_final = np.round(modevalue_final / FINAL_QUANTIZE_DB) * FINAL_QUANTIZE_DB
+
+        threshold_before_margin_guard = _safe_float(threshold)
         margin = 0.05
         if np.isfinite(modevalue_final) and np.isfinite(threshold) and (modevalue_final >= threshold):
+            margin_guard_used = True
             threshold = modevalue_final + margin
-            # keep idx consistent after guard tweak
             idx_threshold = np.searchsorted(intensity_bins, threshold)
             idx_threshold = int(np.clip(idx_threshold, 0, max(0, len(intensity_bins) - 1)))
+        else:
+            margin_guard_used = False
         modevalue = modevalue_final
- 
+
+        threshold_after_margin_guard = _safe_float(threshold)
+        mode_after_margin_guard = _safe_float(modevalue)
+
+
+        # Quantize final outputs
+        if threshold_scale == "db":
+            threshold = np.round(threshold / FINAL_QUANTIZE_DB) * FINAL_QUANTIZE_DB if np.isfinite(threshold) else threshold
+            modevalue = np.round(modevalue / FINAL_QUANTIZE_DB) * FINAL_QUANTIZE_DB if np.isfinite(modevalue) else modevalue
+        if extract_curvefit and curvefit_out_dir is not None:
+            _write_stage_record(curvefit_out_dir, {
+                "stage": "stage_4_threshold_final",
+                "pol": pol,
+                "block_ij": list(block_ij) if block_ij is not None else None,
+                "coord_local": [int(ystart), int(yend), int(xstart), int(xend)],
+                "coord_absolute": [
+                    int(block_origin[0] + ystart),
+                    int(block_origin[0] + yend),
+                    int(block_origin[1] + xstart),
+                    int(block_origin[1] + xend),
+                ] if block_origin is not None else None,
+
+                "threshold_final": _safe_float(threshold),
+                "idx_threshold_final": int(idx_threshold),
+                "mode_final": _safe_float(modevalue),
+
+                # Main threshold trace
+                "threshold_initial": threshold_initial,
+                "threshold_after_ki_or_otsu": threshold_after_ki_or_otsu,
+                "threshold_after_multiotsu": threshold_after_multiotsu,
+                "threshold_after_bimodal_fit": threshold_after_bimodal_fit,
+                "threshold_after_model_intersection": threshold_after_model_intersection,
+                "threshold_after_trimodal_fit": threshold_after_trimodal_fit,
+                "threshold_after_trimodal_override": threshold_after_trimodal_override,
+                "threshold_after_rg": threshold_after_rg,
+                "threshold_before_nonoverlap": threshold_before_nonoverlap,
+                "threshold_after_nonoverlap": threshold_after_nonoverlap,
+                "threshold_before_tile_relax": threshold_before_tile_relax,
+                "threshold_after_tile_relax": threshold_after_tile_relax,
+                "threshold_before_margin_guard": threshold_before_margin_guard,
+                "threshold_after_margin_guard": threshold_after_margin_guard,
+                "hist_trimodal_override_used": bool(hist_trimodal_override_used),
+                # Mode trace
+                "mode_after_bimodal_fit": mode_after_bimodal_fit,
+                "mode_after_model_intersection": mode_after_model_intersection,
+                "mode_after_trimodal_fit": mode_after_trimodal_fit,
+                "mode_after_margin_guard": mode_after_margin_guard,
+
+                # Flags
+                "optimization": bool(optimization),
+                "tri_optimization": bool(tri_optimization),
+                "model_intersection_used": bool(model_intersection_used),
+                "trimodal_override_used": bool(trimodal_override_used),
+                "tile_relax_used": bool(tile_relax_used),
+                "margin_guard_used": bool(margin_guard_used),
+                "threshold_scale": threshold_scale,
+
+                # Fit params
+                "bimodal_params": bimodal_params_debug,
+                "first_mode": first_mode_debug,
+                "second_mode": second_mode_debug,
+                "trimodal_params": trimodal_params_debug,
+                "tri_first_mode": tri_first_mode_debug,
+                "tri_second_mode": tri_second_mode_debug,
+                "tri_third_mode": tri_third_mode_debug,
+            })
+
+        if threshold_scale == "db":
+            if np.isfinite(threshold):
+                threshold = np.round(threshold / FINAL_QUANTIZE_DB) * FINAL_QUANTIZE_DB
+
+            if np.isfinite(modevalue):
+                modevalue = np.round(modevalue / FINAL_QUANTIZE_DB) * FINAL_QUANTIZE_DB
+        else:
+            # Linear case: keep more precision, or quantize in dB then convert back if needed.
+            if np.isfinite(threshold):
+                threshold = np.round(threshold, 8)
+
+            if np.isfinite(modevalue):
+                modevalue = np.round(modevalue, 8)
+
         # add final threshold to threshold list
         threshold_array.append(threshold)
         threshold_idx_array.append(idx_threshold)
@@ -716,7 +1702,11 @@ def run_sub_block(intensity,
                   water_body_subset,
                   cfg,
                   winsize=200,
-                  thres_max=None):
+                  thres_max=None,
+                  extract_curvefit=False,
+                  curvefit_out_dir=None,
+                  block_ij=None,
+                  block_origin=None):
     """
     Process sub-blocks of SAR intensity data for water detection based on
     the specified configuration.
@@ -800,19 +1790,80 @@ def run_sub_block(intensity,
 
     # Tile Selection (with water body)
     for polind, pol in enumerate(pol_list):
+        src_im = np.asarray(intensity[polind], dtype=np.float32)
+        src_im = np.round(src_im, 8).astype(np.float32)
+        tile_selection_im = src_im.copy()
+        tile_selection_im[~np.isfinite(tile_selection_im)] = np.nan
+        tile_selection_im = np.round(tile_selection_im, 8).astype(np.float32)
 
-        candidate_tile_coords = tile_selection_object.tile_selection_wbd(
-                           intensity=intensity[polind, :, :],
-                           water_mask=water_body_subset,
-                           win_size=winsize,
-                           selection_methods=tile_selection_method)
+        if pol in ['VV', 'VH', 'HH', 'HV', 'span', 'ratio']:
+            if threshold_scale == 'db':
+                with np.errstate(divide="ignore", invalid="ignore"):
+                    target_im = _initial_threshold.convert_pow2db(src_im)
 
-        if len(candidate_tile_coords) > 0:
-            if pol in ['VV', 'VH', 'HH', 'HV', 'span', 'ratio']:
-                target_im = _initial_threshold.convert_pow2db(intensity[polind]) \
-                    if threshold_scale == 'db' else intensity[polind]
             else:
-                target_im = intensity[polind]
+                target_im = src_im
+        else:
+            target_im = src_im
+
+        target_im = np.asarray(target_im, dtype=np.float32)
+        tile_im = np.asarray(target_im, dtype=np.float32).copy()
+
+        # Remove non-finite values before tile-selection metrics
+        tile_im[~np.isfinite(tile_im)] = np.nan
+        if threshold_scale == "db":
+            tile_im = np.round(tile_im, 3).astype(np.float32)
+        else:
+            tile_im = np.round(tile_im, 8).astype(np.float32)
+        debug_dir = os.path.join(
+            cfg.groups.product_path_group.scratch_path,
+            "curvefit_debug"
+        )
+        debug_curvefit = False
+        if debug_curvefit:
+            _write_stage_record(debug_dir, {
+                "stage": "stage_1_before_tile_selection",
+                "pol": pol,
+                "polind": int(polind),
+                "block_ij": list(block_ij) if block_ij is not None else None,
+                "input_to_tile_selection": _array_summary(tile_im),
+                "tile_selection_input_linear": _array_summary(tile_selection_im),
+                "threshold_input_db": _array_summary(tile_im),
+                "water_mask": _array_summary(water_body_subset),
+                "winsize": int(winsize),
+                "selection_methods": tile_selection_method,
+            })
+
+        tile_selection_object.debug_tile_metric = False
+        tile_selection_object.debug_metric_dir = debug_dir
+        tile_selection_object.debug_context = {
+            "stage": "stage_1_tile_metric",
+            "pol": pol,
+            "polind": int(polind),
+            "block_ij": list(block_ij) if block_ij is not None else None,
+            "block_origin": list(block_origin) if block_origin is not None else None,
+            "threshold_scale": threshold_scale,
+            "selection_methods": tile_selection_method,
+        }
+        candidate_tile_coords = tile_selection_object.tile_selection_wbd(
+                        intensity=tile_selection_im,
+                        water_mask=water_body_subset,
+                        win_size=winsize,
+                        selection_methods=tile_selection_method)
+        candidate_tile_coords_arr = np.asarray(candidate_tile_coords)
+
+        if debug_curvefit:
+
+            _write_stage_record(debug_dir, {
+                "stage": "stage_1_after_tile_selection",
+                "pol": pol,
+                "polind": int(polind),
+                "block_ij": list(block_ij) if block_ij is not None else None,
+                "n_candidate_tiles": int(len(candidate_tile_coords)),
+                "candidate_tile_coords": candidate_tile_coords_arr.tolist(),
+            })
+        if len(candidate_tile_coords) > 0:
+            target_im = tile_im
             (min_intensity_histogram,
              max_intensity_histogram,
              step_histogram) = _get_histogram_params(pol, threshold_scale)
@@ -857,7 +1908,13 @@ def run_sub_block(intensity,
                 adjust_if_nonoverlap=adjust_threshold_flag,
                 adjust_thresh_low_dist_percent=low_dist_percentile,
                 adjust_thresh_high_dist_percent=high_dist_percentile,
-                )
+                extract_curvefit=extract_curvefit,
+                curvefit_out_dir=curvefit_out_dir,
+                pol=pol,
+                block_ij=block_ij,
+                block_origin=block_origin,
+                threshold_scale=threshold_scale,
+            )
 
             if threshold_scale == 'linear':
                 # intensity_threshold and mode_tau are arrays (or NaNs) in linear power
@@ -954,7 +2011,9 @@ def compute_water_spatial_coverage(
         valid_area = no_data_area == 0
         water_pixel_number += np.sum(water_binary[valid_area])
         valid_pixel_number += np.sum(valid_area)
-
+    if valid_pixel_number == 0:
+        logger.warning("No valid pixels found for water spatial coverage.")
+        return 0.0
     water_percentage = water_pixel_number / valid_pixel_number
     return water_percentage
 
@@ -1014,25 +2073,37 @@ def fill_threshold_and_mode_decoupled_with_gdal(threshold_dict,
     delta_dict = _build_delta_dict(threshold_dict, mode_dict)
 
     # 1) Interpolate threshold -> T
-    _initial_threshold.fill_threshold_with_gdal(threshold_array=threshold_dict,
-                             rows=rows, cols=cols,
-                             filename=filename_threshold,
-                             outputdir=outputdir,
-                             pol_list=pol_list,
-                             filled_value=None,
-                             no_data=no_data,
-                             average_tile=average_tile)
+    _initial_threshold.fill_threshold_with_gdal(
+        threshold_array=threshold_dict,
+        rows=rows,
+        cols=cols,
+        filename=filename_threshold,
+        outputdir=outputdir,
+        pol_list=pol_list,
+        filled_value=None,
+        no_data=no_data,
+        average_tile=average_tile,
+        smooth_sigma=0.75,
+        resample_alg="bilinear",
+        save_cog=True,
+    )
 
     # 2) Interpolate delta -> D  (temporary filename)
     tmp_delta_name = filename_threshold + "_delta"
-    _initial_threshold.fill_threshold_with_gdal(threshold_array=delta_dict,
-                             rows=rows, cols=cols,
-                             filename=tmp_delta_name,
-                             outputdir=outputdir,
-                             pol_list=pol_list,
-                             filled_value=None,
-                             no_data=no_data,
-                             average_tile=average_tile)
+    _initial_threshold.fill_threshold_with_gdal(
+        threshold_array=delta_dict,
+        rows=rows,
+        cols=cols,
+        filename=tmp_delta_name,
+        outputdir=outputdir,
+        pol_list=pol_list,
+        filled_value=None,
+        no_data=no_data,
+        average_tile=average_tile,
+        smooth_sigma=0.75,
+        resample_alg="bilinear",
+        save_cog=False,
+    )
 
     # 3) Compose mode = threshold - max(delta, margin) and write out
     for pol in pol_list:
@@ -1065,7 +2136,7 @@ def fill_threshold_and_mode_decoupled_with_gdal(threshold_dict,
         d_ds = None
 
         _dswx_sar_util._save_as_cog(m_path, outputdir, logger,
-                                   compression='DEFLATE', nbits=16)
+                                   compression='DEFLATE', nbits=None)
 
 
 def process_block(ii, jj,
@@ -1129,21 +2200,55 @@ def process_block(ii, jj,
     image_sub = filt_raster_tif.ReadAsArray(jj * block_col,
                                             ii * block_row,
                                             x_size,
-                                            y_size)
+                                            y_size,
+                                            buf_type=gdal.GDT_Float32
+                                            )
+    image_sub = np.asarray(image_sub, dtype=np.float32)
+    if getattr(cfg.groups.processing.initial_threshold, "force_float16_debug", False):
+        image_sub = image_sub.astype(np.float16).astype(np.float32)
     filt_raster_tif = None
 
     wbd_gdal = gdal.Open(wbd_im_str)
     wbd_sub = wbd_gdal.ReadAsArray(jj * block_col,
                                    ii * block_row,
                                    x_size,
-                                   y_size)
+                                   y_size,
+                                   buf_type=gdal.GDT_Byte
+                                )
     wbd_gdal = None
+    wbd_sub = np.asarray(wbd_sub, dtype=np.uint8)
+    debug_dir = os.path.join(
+        cfg.groups.product_path_group.scratch_path,
+        "curvefit_debug"
+    )
+    debug_curvefit = False
+    if debug_curvefit:
+        _write_stage_record(debug_dir, {
+            "stage": "stage_0_block_read",
+            "block_ij": [int(ii), int(jj)],
+            "block_origin": [int(ii * block_row), int(jj * block_col)],
+            "x_size": int(x_size),
+            "y_size": int(y_size),
+            "image": _array_summary(image_sub),
+            "wbd": _array_summary(wbd_sub),
+        })
+    block_origin = (ii * block_row, jj * block_col)
+    block_ij = (ii, jj)
+    curvefit_out_dir = os.path.join(
+        cfg.groups.product_path_group.scratch_path,
+        "curvefit_cases"
+    )
+
     threshold_tau_block, mode_tau_block, candidate_tile_coords = \
         run_sub_block(
             image_sub,
             wbd_sub,
             cfg,
-            thres_max=thres_max)
+            thres_max=thres_max,
+            extract_curvefit=False,
+            curvefit_out_dir=curvefit_out_dir,
+            block_ij=block_ij,
+            block_origin=block_origin)
 
     if average_tile_flag:
         threshold_list = [np.nanmedian(test_threshold)
@@ -1348,11 +2453,11 @@ def run(cfg):
                 block_col)
 
         else:
-            threshold_tau_set = [[], [], []]
-            mode_tau_set = [[], [], []]
-            coord_row_list = [[], [], []]
-            coord_col_list = [[], [], []]
-            window_coord_list = [[], [], []]
+            threshold_tau_set = [[] for _ in range(band_number)]
+            mode_tau_set = [[] for _ in range(band_number)]
+            coord_row_list = [[] for _ in range(band_number)]
+            coord_col_list = [[] for _ in range(band_number)]
+            window_coord_list = [[] for _ in range(band_number)]
 
             for ii, jj, threshold_tau_blocks, mode_tau_blocks, window_coords \
                     in results:
@@ -1414,24 +2519,20 @@ def run(cfg):
             logger.info('No threshold_tau')
         # Currently, only 'gdal_grid' method is supported.
         if threshold_extending_method == 'gdal_grid':
-            dict_threshold_list = [threshold_tau_dict, mode_tau_dict]
-            interp_thres_str_list = ['intensity_threshold_filled',
-                                     'mode_tau_filled']
-            for dict_thres, thres_str in zip(dict_threshold_list,
-                                             interp_thres_str_list):
-                fill_threshold_and_mode_decoupled_with_gdal(
-                    threshold_dict=threshold_tau_dict,
-                    mode_dict=mode_tau_dict,
-                    rows=height,
-                    cols=width,
-                    filename_threshold='intensity_threshold_filled',
-                    filename_mode='mode_tau_filled',
-                    outputdir=outputdir,
-                    pol_list=pol_list,
-                    margin=0.05,
-                    no_data=-50,
-                    average_tile=average_threshold_flag
-                )
+
+            fill_threshold_and_mode_decoupled_with_gdal(
+                threshold_dict=threshold_tau_dict,
+                mode_dict=mode_tau_dict,
+                rows=height,
+                cols=width,
+                filename_threshold='intensity_threshold_filled',
+                filename_mode='mode_tau_filled',
+                outputdir=outputdir,
+                pol_list=pol_list,
+                margin=0.05,
+                no_data=-50,
+                average_tile=average_threshold_flag
+            )
                 # fill_threshold_with_gdal(
                 #     threshold_array=dict_thres,
                 #     rows=height,
@@ -1446,6 +2547,7 @@ def run(cfg):
     if processing_cfg.debug_mode:
 
         intensity_whole = _dswx_sar_util.read_geotiff(filt_im_str)
+        intensity_whole = np.asarray(intensity_whole, dtype=np.float32)
         if intensity_whole.ndim == 2:
             intensity_whole = np.expand_dims(intensity_whole,
                                              axis=0)

--- a/src/dswx_sar/schemas/algorithm_parameter_ni.yaml
+++ b/src/dswx_sar/schemas/algorithm_parameter_ni.yaml
@@ -231,6 +231,10 @@ runconfig:
             # 'auto' determine the inundated vegetation availability
             # based on available cross-polarizations
             enabled: enum(True, False, 'auto')
+
+            # Default dual-pol ratio and intensity thresholds.
+            # These are used as fallback values when class-specific
+            # thresholds are not provided.
             dual_pol_ratio_max: num(min=0, max=30, required=False)
             dual_pol_ratio_min: num(min=0, max=30, required=False)
             dual_pol_ratio_threshold: num(min=0, max=30, required=False)
@@ -238,23 +242,57 @@ runconfig:
             copol_threshold: num(min=-30, max=10, required=False)
             line_per_block: num(min=1, required=False)
 
+            # Optional class-specific thresholds for tree-covered
+            # inundated vegetation.
+            # If omitted, the default dual_pol_ratio_threshold,
+            # cross_pol_min, and copol_threshold are reused.
+            tree_dual_pol_ratio_threshold: num(min=0, max=30, required=False)
+            tree_cross_pol_min: num(min=-30, max=10, required=False)
+            tree_copol_threshold: num(min=-30, max=10, required=False)
+
+            # Optional class-specific thresholds for short-vegetation
+            # inundated areas, such as herbaceous wetland, grassland,
+            # shrub, or crop-like vegetation depending on GLAD class setup.
+            # If omitted, the default dual_pol_ratio_threshold,
+            # cross_pol_min, and copol_threshold are reused.
+            short_vegetation_dual_pol_ratio_threshold: num(min=0, max=30, required=False)
+            short_vegetation_cross_pol_min: num(min=-30, max=10, required=False)
+            short_vegetation_copol_threshold: num(min=-30, max=10, required=False)
+
             # If 'auto' is selected and GLAD is available, GLAD will be
             # used for inundated vegetation. In the 'auto' option,
-            # GLAD is not provided, then WorldCover will be used to extract
+            # if GLAD is not provided, then WorldCover will be used to extract
             # the target areas.
             target_area_file_type: enum('WorldCover', 'GLAD', 'auto')
 
-            # Land covers where the inundated vegetation is detected.
+            # Land covers where inundated vegetation is detected.
+            # This is the full target vegetation class list.
             target_worldcover_class: list(required=False)
             target_glad_class: list(required=False)
+
+            # Optional GLAD class split for tree and short vegetation.
+            # These are used to apply class-specific thresholds and to
+            # restrict DEM/open-water connectivity refinement to short
+            # vegetation only.
+            #
+            # If both target_glad_tree_class and
+            # target_glad_short_vegetation_class are omitted, all GLAD target
+            # vegetation is treated with the original behavior.
+            target_glad_tree_class: list(required=False)
+            target_glad_short_vegetation_class: list(required=False)
 
             # Optional refinement for inundated vegetation using fuzzy logic
             # and region growing. This refinement is applied after the
             # initial dual-pol-ratio-based inundated vegetation detection.
             #
-            # The fuzzy score is computed using dual-pol ratio, HAND, and
-            # slope membership. Reference water is intentionally excluded
+            # The base fuzzy score is computed using dual-pol ratio, HAND,
+            # and slope membership. Reference water is intentionally excluded
             # from this refinement.
+            #
+            # If water_connectivity is enabled, DEM/open-water connectivity is
+            # used only for short vegetation. Tree-covered pixels keep the
+            # original SAR/topographic fuzzy behavior because DEM may represent
+            # canopy height rather than the true ground surface.
             fuzzy_refinement:
                 enabled: bool(required=False)
 
@@ -304,6 +342,58 @@ runconfig:
                 # Block size for IV fuzzy computation.
                 # If omitted, inundated_vegetation.line_per_block can be reused.
                 line_per_block: num(min=1, required=False)
+
+                # Optional cross-pol term for fuzzy refinement.
+                #
+                # 'none':
+                #     Do not use cross-pol in fuzzy score.
+                #
+                # 'soft':
+                #     Use cross-pol as a soft penalty:
+                #     fuzzy *= (1 - weight) + weight * cross_s
+                #
+                # 'hard':
+                #     Set fuzzy to zero where cross-pol is below threshold.
+                cross_pol_fuzzy_mode: enum('none', 'soft', 'hard', required=False)
+
+                # Width in dB for cross-pol fuzzy transition above the
+                # class-specific cross-pol threshold.
+                # For example, if cross_pol_min=-26 and margin=2,
+                # cross_s transitions from -26 to -24 dB.
+                cross_pol_soft_margin: num(min=0, required=False)
+
+                # Strength of soft cross-pol penalty.
+                # Used only when cross_pol_fuzzy_mode='soft'.
+                cross_pol_weight: num(min=0, max=1, required=False)
+
+                # Optional DEM/open-water connectivity support for
+                # short-vegetation inundation refinement.
+                #
+                # This layer grows from reliable open-water seeds using DEM
+                # constraints. Growth stops where DEM elevation is higher than
+                # the propagated water level plus dz_max. The resulting
+                # connectivity fuzzy layer is applied only to short vegetation,
+                # not to tree-covered vegetation.
+                water_connectivity:
+                    enabled: bool(required=False)
+
+                    # Maximum allowed elevation above propagated water level
+                    # during DEM-constrained growth, in meters.
+                    dz_max: num(min=0, required=False)
+
+                    # Maximum growing distance from open-water seeds, in pixels.
+                    max_distance_pixels: num(min=1, required=False)
+
+                    # Pixel connectivity for region growing.
+                    # 4: cardinal directions only
+                    # 8: cardinal + diagonal directions
+                    connectivity: enum(4, 8, required=False)
+
+                    # Weight used to apply water connectivity to short vegetation.
+                    # For example, with weight=0.5:
+                    #     short_fuzzy = sar_fuzzy * (0.5 + 0.5 * water_conn_s)
+                    # If omitted, 0.5 can be used.
+                    weight: num(min=0, max=1, required=False)
 
             filter:
                 enabled: bool(required=False)


### PR DESCRIPTION
This PR improves the stability and cross-platform reproducibility of the initial threshold estimation workflow.

The main changes include:

- Introduced deterministic histogram peak selection to avoid threshold differences caused by nearly equal histogram peaks on Intel, AMD, and macOS systems.
- Added histogram smoothing and deterministic tie-breaking when identifying dominant low- and high-intensity modes.
- Standardized histogram inputs through explicit data types, rounding, and sanitization of non-finite values.
- Added deterministic histogram-based Otsu and multi-Otsu threshold calculations.
- Added validation checks for bimodal and trimodal Gaussian fitting results before using fitted parameters.
- Added a conservative Gaussian-intersection-based threshold adjustment with a maximum allowed threshold shift.
- Added a histogram-based trimodal threshold override for cases where a third distribution affects the initial threshold.
- Added tile-level threshold relaxation based on water and land core distributions near the detected boundary.
- Quantized final thresholds and mode values to reduce sensitivity to small floating-point differences.
- Added a final margin check to ensure that the estimated water mode remains below the selected threshold.
- Added detailed debugging outputs, array summaries, hashes, threshold traces, and saved curve-fitting inputs to support reproducibility analysis.
- Improved handling of invalid, empty, and non-finite input values.

These updates are intended to produce more consistent water-detection thresholds across different hardware platforms while retaining the existing thresholding behavior for well-separated distributions.